### PR TITLE
refactor!(CircleCI): Remove default export

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ $ npm i --save @circleci/circleci-config-sdk
 In Node.js:
 
 ```typescript
-import CircleCI from '@circleci/circleci-config-sdk';
+import * as CircleCI from '@circleci/circleci-config-sdk';
 ```
 
 In Browser:

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,34 +5,4 @@ import Workflow from './lib/Components/Workflow';
 import Config from './lib/Config';
 import Pipeline from './lib/Config/Pipeline/index';
 
-/**
- * The CircleCI config SDK. Build your CircleCI configuration with code.
- */
-const CircleCI = {
-  Command,
-  /**
-   * Executors define the environment in which the steps of a job will be run. {@link https://circleci.com/docs/2.0/configuration-reference/#executors-requires-version-21}
-   */
-  Executor,
-  /**
-   * Jobs define a collection of steps to be run within a given executor, and are orchestrated using Workflows.
-   */
-  Job,
-  /**
-   * A workflow is a set of rules for defining a collection of jobs and their run order.
-   */
-  Workflow,
-  /**
-   * Access information about the Current CircleCI Pipeline
-   */
-  Pipeline,
-  /**
-   * A CircleCI configuration
-   */
-  Config,
-};
-
-// Exported for documentation
 export { Command, Executor, Job, Workflow, Pipeline, Config };
-
-export default CircleCI;

--- a/tests/BasicNodeExample.test.ts
+++ b/tests/BasicNodeExample.test.ts
@@ -1,4 +1,4 @@
-import CircleCI from '../src/index';
+import * as CircleCI from '../src/index';
 import * as YAML from 'yaml';
 describe('Generate a Hello World config', () => {
   // Instantiate new Config

--- a/tests/Commands.test.ts
+++ b/tests/Commands.test.ts
@@ -1,4 +1,4 @@
-import CircleCI from '../src/index';
+import * as CircleCI from '../src/index';
 
 describe('Instantiate a Run step', () => {
   const run = new CircleCI.Command.Run({

--- a/tests/Config.test.ts
+++ b/tests/Config.test.ts
@@ -1,4 +1,4 @@
-import CircleCI from '../src/index';
+import * as CircleCI from '../src/index';
 import * as YAML from 'yaml';
 
 describe('Generate a Setup workflow config', () => {

--- a/tests/Executor.test.ts
+++ b/tests/Executor.test.ts
@@ -1,4 +1,4 @@
-import CircleCI from '../src/index';
+import * as CircleCI from '../src/index';
 import * as YAML from 'yaml';
 
 describe('Instantiate Docker Executor', () => {

--- a/tests/Job.test.ts
+++ b/tests/Job.test.ts
@@ -1,4 +1,4 @@
-import CircleCI from '../src/index';
+import * as CircleCI from '../src/index';
 import * as YAML from 'yaml';
 
 describe('Instantiate Docker Job', () => {

--- a/tests/Pipelines.test.ts
+++ b/tests/Pipelines.test.ts
@@ -1,4 +1,4 @@
-import CircleCI from '../src/index';
+import * as CircleCI from '../src/index';
 import { PipelineParameter } from '../src/lib/Config/Pipeline';
 // Enforce local testing
 delete process.env.CIRCLECI;

--- a/tests/Workflow.test.ts
+++ b/tests/Workflow.test.ts
@@ -1,4 +1,4 @@
-import CircleCI from '../src/index';
+import * as CircleCI from '../src/index';
 import * as YAML from 'yaml';
 
 describe('Instantiate Workflow', () => {

--- a/tests/WorkspacesExample.test.ts
+++ b/tests/WorkspacesExample.test.ts
@@ -1,4 +1,4 @@
-import CircleCI from '../src/index';
+import * as CircleCI from '../src/index';
 import * as YAML from 'yaml';
 describe('Generate a config utilizing Workspaces', () => {
   // Create a new CircleCI Config


### PR DESCRIPTION
Removed the `CircleCI` default export.

No need to duplicate exports for the sake of having a named default export. 