### PR TITLE
refactor!: Remove reusable executors

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,14 +40,12 @@ const myConfig = new CircleCI.Config();
 const myWorkflow = new CircleCI.Workflow('myWorkflow');
 myConfig.addWorkflow(myWorkflow);
 
-// Create an executor. Reusable.
-const nodeExecutor = new CircleCI.Executor.DockerExecutor(
-  'node-executor',
-  'cimg/node:lts',
-);
-myConfig.addExecutor(nodeExecutor);
+// Create an executor instance
+// Executors are used directly in jobs
+// and do not need to be added to the config separately
+const nodeExecutor = new CircleCI.Executor.DockerExecutor('cimg/node:lts');
 
-// Create Job
+// Create Job and add it to the config
 const nodeTestJob = new CircleCI.Job('node-test', nodeExecutor);
 myConfig.addJob(nodeTestJob);
 
@@ -77,14 +75,10 @@ const MyYamlConfig = myConfig.stringify();
 
 ```yaml
 version: 2.1
-executors:
-  node-executor:
-    docker:
-      - image: cimg/node:lts
 jobs:
   node-test:
-    executor:
-      name: node-executor
+    docker:
+      - image: cimg/node:lts
     steps:
       - run:
           command: npm install

--- a/sample/01-dynamic-workflow-javascript/.circleci/dynamic/index.js
+++ b/sample/01-dynamic-workflow-javascript/.circleci/dynamic/index.js
@@ -2,7 +2,6 @@ const CircleCI = require("@circleci/circleci-config-sdk");
 const fs = require('fs');
 
 // Import Config Components
-const dockerNode = require("./executors/docker-node");
 const jobA = require("./jobs/jobA");
 const jobB = require("./jobs/jobB");
 
@@ -10,7 +9,7 @@ const jobB = require("./jobs/jobB");
 const myConfig = new CircleCI.Config()
 
 // Add elements to the config
-myConfig.addExecutor(dockerNode)
+myConfig
   .addJob(jobA)
   .addJob(jobB)
 

--- a/src/lib/Components/Executor/DockerExecutor.ts
+++ b/src/lib/Components/Executor/DockerExecutor.ts
@@ -12,11 +12,16 @@ import { DockerImage } from './DockerImage';
  */
 export class DockerExecutor extends AbstractExecutor {
   /**
-   * The name of a custom Docker image to use
+   * The name of a custom Docker image to use.
+   * @example
+   * ```
+   * "cimg/base:stable"
+   * ```
    */
   image: DockerImage;
   /**
-   * Add additional Docker images which will be accessable from the primary container. This is typically used for adding a database as a service container.
+   * Add additional Docker images which will be accessible from the primary container.
+   * This is typically used for adding a database as a service container.
    */
   serviceImages: DockerImage[] = [];
   /**
@@ -25,12 +30,8 @@ export class DockerExecutor extends AbstractExecutor {
    * @param image - The primary docker container image.
    */
   resourceClass: DockerResourceClass;
-  constructor(
-    name: string,
-    image: string,
-    resourceClass: DockerResourceClass = 'medium',
-  ) {
-    super(name, resourceClass);
+  constructor(image: string, resourceClass: DockerResourceClass = 'medium') {
+    super(resourceClass);
     const newImage = new DockerImage(image);
     this.image = newImage;
     this.resourceClass = resourceClass;
@@ -49,10 +50,8 @@ export class DockerExecutor extends AbstractExecutor {
       });
     });
     return {
-      [this.name]: {
-        docker: dockerImageMap,
-        resource_class: this.resourceClass,
-      },
+      docker: dockerImageMap,
+      resource_class: this.resourceClass,
     };
   }
 }

--- a/src/lib/Components/Executor/DockerExecutor.types.ts
+++ b/src/lib/Components/Executor/DockerExecutor.types.ts
@@ -1,9 +1,7 @@
 import { DockerImageSchema } from './DockerImage';
 export interface DockerExecutorSchema {
-  [name: string]: {
-    docker: DockerImageSchema[];
-    resource_class: DockerResourceClass;
-  };
+  docker: DockerImageSchema[];
+  resource_class: DockerResourceClass;
 }
 export interface DockerImageMap {
   image: string;

--- a/src/lib/Components/Executor/Executor.ts
+++ b/src/lib/Components/Executor/Executor.ts
@@ -5,12 +5,10 @@ import { ExecutorSchema } from './Executor.types';
  * A generic reusable Executor
  */
 export abstract class AbstractExecutor extends Component {
-  name: string;
   description?: string;
   resourceClass: string;
-  constructor(name: string, resourceClass: string, description?: string) {
+  constructor(resourceClass: string, description?: string) {
     super();
-    this.name = name;
     this.description = description;
     this.resourceClass = resourceClass;
   }

--- a/src/lib/Components/Executor/MacOSExecutor.ts
+++ b/src/lib/Components/Executor/MacOSExecutor.ts
@@ -9,26 +9,20 @@ export class MacOSExecutor extends AbstractExecutor {
   resourceClass: MacOSResourceClass;
   /**
    * Select an xcode version
-   * @see {@link https://circleci.com/docs/2.0/testing-ios/#supported-xcode-versions}
+   * @see {@link https://circleci.com/developer/machine/image/macos}
    */
   xcode: string;
-  constructor(
-    name: string,
-    xcode: string,
-    resourceClass: MacOSResourceClass = 'medium',
-  ) {
-    super(name, resourceClass);
+  constructor(xcode: string, resourceClass: MacOSResourceClass = 'medium') {
+    super(resourceClass);
     this.xcode = xcode;
     this.resourceClass = resourceClass;
   }
   generate(): MacOSExecutorSchema {
     return {
-      [this.name]: {
-        macos: {
-          xcode: this.xcode,
-        },
-        resource_class: this.resourceClass,
+      macos: {
+        xcode: this.xcode,
       },
+      resource_class: this.resourceClass,
     };
   }
 }

--- a/src/lib/Components/Executor/MacOSExecutor.types.ts
+++ b/src/lib/Components/Executor/MacOSExecutor.types.ts
@@ -1,10 +1,8 @@
 export interface MacOSExecutorSchema {
-  [name: string]: {
-    macos: {
-      xcode: string;
-    };
-    resource_class: MacOSResourceClass;
+  macos: {
+    xcode: string;
   };
+  resource_class: MacOSResourceClass;
 }
 
 /**

--- a/src/lib/Components/Executor/MachineExecutor.ts
+++ b/src/lib/Components/Executor/MachineExecutor.ts
@@ -9,25 +9,23 @@ import {
  * @see {@link https://circleci.com/docs/2.0/executor-types/#using-machine}
  */
 export class MachineExecutor extends AbstractExecutor {
+  /**
+   * Select one of the Ubuntu Linux VM Images provided by CircleCI.
+   * @see - https://circleci.com/developer/machine
+   */
   image = 'ubuntu-2004:202010-01';
   resourceClass: MachineResourceClass;
-  constructor(
-    name: string,
-    resourceClass: MachineResourceClass = 'medium',
-    image?: string,
-  ) {
-    super(name, resourceClass);
+  constructor(resourceClass: MachineResourceClass = 'medium', image?: string) {
+    super(resourceClass);
     this.image = image || this.image;
     this.resourceClass = resourceClass;
   }
   generate(): MachineExecutorSchema {
     return {
-      [this.name]: {
-        machine: {
-          image: this.image,
-        },
-        resource_class: this.resourceClass,
+      machine: {
+        image: this.image,
       },
+      resource_class: this.resourceClass,
     };
   }
 }

--- a/src/lib/Components/Executor/MachineExecutor.types.ts
+++ b/src/lib/Components/Executor/MachineExecutor.types.ts
@@ -1,10 +1,8 @@
 export interface MachineExecutorSchema {
-  [name: string]: {
-    machine: {
-      image: string;
-    };
-    resource_class: MachineResourceClass;
+  machine: {
+    image: string;
   };
+  resource_class: MachineResourceClass;
 }
 
 /**

--- a/src/lib/Components/Executor/WindowsExecutor.ts
+++ b/src/lib/Components/Executor/WindowsExecutor.ts
@@ -2,6 +2,7 @@ import { AbstractExecutor } from './Executor';
 import {
   WindowsExecutorSchema,
   WindowsResourceClass,
+  WindowsResourceClassGenerated,
 } from './WindowsExecutor.types';
 
 /**
@@ -9,26 +10,25 @@ import {
  * @see {@link https://circleci.com/docs/2.0/executor-types/#using-the-windows-executor}
  */
 export class WindowsExecutor extends AbstractExecutor {
+  /**
+   * Select one of the available Windows VM Images provided by CircleCI
+   * @see - https://circleci.com/developer/machine
+   */
   image = 'windows-server-2019-vs2019:stable';
   resourceClass: WindowsResourceClass;
-  constructor(
-    name: string,
-    resourceClass: WindowsResourceClass = 'medium',
-    image?: string,
-  ) {
-    super(name, resourceClass);
+  constructor(resourceClass: WindowsResourceClass = 'medium', image?: string) {
+    super(resourceClass);
     this.image = image || this.image;
     this.resourceClass = resourceClass;
   }
   generate(): WindowsExecutorSchema {
     return {
-      [this.name]: {
-        machine: {
-          image: this.image,
-        },
-        resource_class: `windows.${this.resourceClass}`,
-        shell: 'powershell.exe -ExecutionPolicy Bypass',
+      machine: {
+        image: this.image,
       },
+      resource_class:
+        `windows.${this.resourceClass}` as WindowsResourceClassGenerated,
+      shell: 'powershell.exe -ExecutionPolicy Bypass',
     };
   }
 }

--- a/src/lib/Components/Executor/WindowsExecutor.types.ts
+++ b/src/lib/Components/Executor/WindowsExecutor.types.ts
@@ -1,11 +1,9 @@
 export interface WindowsExecutorSchema {
-  [name: string]: {
-    machine: {
-      image: string;
-    };
-    resource_class: string; // windows.WindowsResourceClass
-    shell: 'powershell.exe -ExecutionPolicy Bypass';
+  machine: {
+    image: string;
   };
+  resource_class: WindowsResourceClassGenerated;
+  shell: 'powershell.exe -ExecutionPolicy Bypass';
 }
 
 /**
@@ -13,3 +11,12 @@ export interface WindowsExecutorSchema {
  * @see {@link https://circleci.com/docs/2.0/configuration-reference/#windows-executor} for specifications of each class.
  */
 export type WindowsResourceClass = 'medium' | 'large' | 'xlarge' | '2xlarge';
+
+/**
+ * Completed resource class after generation, including the windows prefix.
+ */
+export type WindowsResourceClassGenerated =
+  | 'windows.medium'
+  | 'windows.large'
+  | 'windows.xlarge'
+  | 'windows.2xlarge';

--- a/src/lib/Components/Executor/index.ts
+++ b/src/lib/Components/Executor/index.ts
@@ -1,3 +1,6 @@
+/**
+ * Instantiate a CircleCI Executor, the build environment for a job. Select a type of executor and supply the required parameters.
+ */
 export { DockerExecutor } from './DockerExecutor';
 export { MachineExecutor } from './MachineExecutor';
 export { MacOSExecutor } from './MacOSExecutor';

--- a/src/lib/Components/Job/index.ts
+++ b/src/lib/Components/Job/index.ts
@@ -1,5 +1,6 @@
 import { Command } from '../Commands/Command';
 import { AbstractExecutor } from '../Executor/Executor';
+import { ExecutorSchema } from '../Executor/Executor.types';
 import { Component } from '../index';
 
 /**
@@ -39,13 +40,13 @@ export class Job extends Component {
     const generatedSteps = this.steps.map((step) => {
       return step.generate();
     });
+    const generatedExecutor = this.executor.generate();
+    const jobContents: JobContentSchema = {
+      steps: generatedSteps,
+      ...generatedExecutor,
+    };
     return {
-      [this.name]: {
-        executor: {
-          name: this.executor.name,
-        },
-        steps: generatedSteps,
-      },
+      [this.name]: jobContents,
     };
   }
 
@@ -58,11 +59,12 @@ export class Job extends Component {
     return this;
   }
 }
+
+export interface JobStepsSchema {
+  steps: unknown[]; // CommandSchemas for any command.
+}
+
+export type JobContentSchema = JobStepsSchema & ExecutorSchema;
 export interface JobSchema {
-  [key: string]: {
-    executor: {
-      name: string;
-    };
-    steps: unknown[]; // CommandSchemas for any command.
-  };
+  [key: string]: JobContentSchema;
 }

--- a/tests/BasicNodeExample.test.ts
+++ b/tests/BasicNodeExample.test.ts
@@ -8,11 +8,7 @@ describe('Generate a Hello World config', () => {
   myConfig.addWorkflow(myWorkflow);
 
   // Create an executor. Reusable.
-  const nodeExecutor = new CircleCI.Executor.DockerExecutor(
-    'node-executor',
-    'cimg/node:lts',
-  );
-  myConfig.addExecutor(nodeExecutor);
+  const nodeExecutor = new CircleCI.Executor.DockerExecutor('cimg/node:lts');
 
   // Create Job
   const nodeTestJob = new CircleCI.Job('node-test', nodeExecutor);
@@ -41,15 +37,10 @@ describe('Generate a Hello World config', () => {
     const expectedResult = {
       version: 2.1,
       setup: false,
-      executors: {
-        'node-executor': {
-          docker: [{ image: 'cimg/node:lts' }],
-          resource_class: 'medium',
-        },
-      },
       jobs: {
         'node-test': {
-          executor: { name: 'node-executor' },
+          docker: [{ image: 'cimg/node:lts' }],
+          resource_class: 'medium',
           steps: [
             {
               run: {

--- a/tests/Commands.test.ts
+++ b/tests/Commands.test.ts
@@ -6,7 +6,7 @@ describe('Instantiate a Run step', () => {
   });
   const runStep = run.generate();
   const expectedResult = { run: { command: 'echo hello world' } };
-  it('Should genreate checkout yaml', () => {
+  it('Should generate checkout yaml', () => {
     expect(runStep).toEqual(expectedResult);
   });
 });

--- a/tests/Config.test.ts
+++ b/tests/Config.test.ts
@@ -8,7 +8,6 @@ describe('Generate a Setup workflow config', () => {
     const expected = {
       version: 2.1,
       setup: true,
-      executors: {},
       jobs: {},
       workflows: {},
     };

--- a/tests/Executor.test.ts
+++ b/tests/Executor.test.ts
@@ -3,13 +3,12 @@ import * as YAML from 'yaml';
 
 describe('Instantiate Docker Executor', () => {
   const docker = new CircleCI.Executor.DockerExecutor(
-    'docker-executor',
     'cimg/node:lts',
   ).generate();
-  const expectedYAML = `docker-executor:
-  docker:
-    - image: cimg/node:lts
-  resource_class: "medium"`;
+  const expectedYAML = `
+docker:
+  - image: cimg/node:lts
+resource_class: "medium"`;
 
   it('Should match the expected output', () => {
     expect(docker).toEqual(YAML.parse(expectedYAML));
@@ -17,13 +16,11 @@ describe('Instantiate Docker Executor', () => {
 });
 
 describe('Instantiate Machine Executor', () => {
-  const machine = new CircleCI.Executor.MachineExecutor(
-    'machine-executor',
-  ).generate();
-  const expectedYAML = `machine-executor:
-  machine:
-    image: ubuntu-2004:202010-01
-  resource_class: "medium"`;
+  const machine = new CircleCI.Executor.MachineExecutor().generate();
+  const expectedYAML = `
+machine:
+  image: ubuntu-2004:202010-01
+resource_class: "medium"`;
 
   it('Should match the expected output', () => {
     expect(machine).toEqual(YAML.parse(expectedYAML));
@@ -32,14 +29,13 @@ describe('Instantiate Machine Executor', () => {
 
 describe('Instantiate MacOS Executor', () => {
   const macos = new CircleCI.Executor.MacOSExecutor(
-    'mac-executor',
     '13.0.0',
     'medium',
   ).generate();
-  const expectedYAML = `mac-executor:
-    macos:
-      xcode: "13.0.0"
-    resource_class: medium`;
+  const expectedYAML = `
+macos:
+  xcode: "13.0.0"
+resource_class: medium`;
 
   it('Should match the expected output', () => {
     expect(macos).toEqual(YAML.parse(expectedYAML));
@@ -48,14 +44,13 @@ describe('Instantiate MacOS Executor', () => {
 
 describe('Instantiate Large MacOS Executor', () => {
   const macos = new CircleCI.Executor.MacOSExecutor(
-    'mac-executor',
     '13.0.0',
     'large',
   ).generate();
-  const expectedYAML = `mac-executor:
-    macos:
-      xcode: "13.0.0"
-    resource_class: large`;
+  const expectedYAML = `
+macos:
+  xcode: "13.0.0"
+resource_class: large`;
 
   it('Should match the expected output', () => {
     expect(macos).toEqual(YAML.parse(expectedYAML));
@@ -63,14 +58,12 @@ describe('Instantiate Large MacOS Executor', () => {
 });
 
 describe('Instantiate Windows Executor', () => {
-  const windows = new CircleCI.Executor.WindowsExecutor(
-    'win-executor',
-  ).generate();
-  const expectedYAML = `win-executor:
-  machine:
-    image: "windows-server-2019-vs2019:stable"
-  resource_class: "windows.medium"
-  shell: powershell.exe -ExecutionPolicy Bypass`;
+  const windows = new CircleCI.Executor.WindowsExecutor().generate();
+  const expectedYAML = `
+machine:
+  image: "windows-server-2019-vs2019:stable"
+resource_class: "windows.medium"
+shell: powershell.exe -ExecutionPolicy Bypass`;
 
   it('Should match the expected output', () => {
     expect(windows).toEqual(YAML.parse(expectedYAML));
@@ -79,28 +72,24 @@ describe('Instantiate Windows Executor', () => {
 
 describe('Instantiate a 2xlarge Docker Executor', () => {
   const xxlDocker = new CircleCI.Executor.DockerExecutor(
-    'docker-executor',
     'cimg/node:lts',
     '2xlarge',
   ).generate();
-  const expectedYAML = `docker-executor:
-    docker:
-      - image: cimg/node:lts
-    resource_class: 2xlarge`;
+  const expectedYAML = `
+docker:
+  - image: cimg/node:lts
+resource_class: 2xlarge`;
   it('Should match the expected output', () => {
     expect(xxlDocker).toEqual(YAML.parse(expectedYAML));
   });
 });
 
 describe('Instantiate Large Machine Executor', () => {
-  const machine = new CircleCI.Executor.MachineExecutor(
-    'machine-executor',
-    'large',
-  ).generate();
-  const expectedYAML = `machine-executor:
-  machine:
-    image: ubuntu-2004:202010-01
-  resource_class: "large"`;
+  const machine = new CircleCI.Executor.MachineExecutor('large').generate();
+  const expectedYAML = `
+machine:
+  image: ubuntu-2004:202010-01
+resource_class: "large"`;
 
   it('Should match the expected output', () => {
     expect(machine).toEqual(YAML.parse(expectedYAML));

--- a/tests/Job.test.ts
+++ b/tests/Job.test.ts
@@ -2,17 +2,15 @@ import * as CircleCI from '../src/index';
 import * as YAML from 'yaml';
 
 describe('Instantiate Docker Job', () => {
-  const docker = new CircleCI.Executor.DockerExecutor(
-    'docker-executor',
-    'cimg/node:lts',
-  );
+  const docker = new CircleCI.Executor.DockerExecutor('cimg/node:lts');
   const helloWorld = new CircleCI.Command.Run({
     command: 'echo hello world',
   });
   const job = new CircleCI.Job('my-job', docker, [helloWorld]);
   const expectedOutput = `my-job:
-  executor:
-    name: docker-executor
+  docker:
+    - image: cimg/node:lts
+  resource_class: medium
   steps:
     - run:
         command: echo hello world`;
@@ -22,7 +20,6 @@ describe('Instantiate Docker Job', () => {
   });
   it('Add job to config and validate', () => {
     const myConfig = new CircleCI.Config();
-    myConfig.addExecutor(docker);
     myConfig.addJob(job);
     expect(myConfig.jobs.length).toBeGreaterThan(0);
   });

--- a/tests/MatrixTestGeneration.test.ts
+++ b/tests/MatrixTestGeneration.test.ts
@@ -1,0 +1,27 @@
+import * as CircleCI from '../src/index';
+
+// Generate a "Matrix" of Jobs with node executors, testing node versions: 13.0.0, 16.0.0, 18.0.0
+describe('Generate 3 node-based jobs with different node versions', () => {
+  const config = new CircleCI.Config();
+  const nodeVersions = ['13.0.0', '16.0.0', '18.0.0'];
+  const workflow = new CircleCI.Workflow('my-workflow');
+  const helloWorld = new CircleCI.Command.Run({
+    command: 'echo hello world',
+  });
+
+  nodeVersions.forEach((version) => {
+    const docker = new CircleCI.Executor.DockerExecutor(`cimg/node:${version}`);
+    const job = new CircleCI.Job(`test-${version}`, docker, [helloWorld]);
+    config.addJob(job);
+    workflow.addJob(job);
+  });
+
+  config.addWorkflow(workflow);
+
+  it('The config should contain three jobs', () => {
+    expect(config.jobs.length).toEqual(3);
+  });
+  it('The config workflow should contain three jobs', () => {
+    expect(config.workflows[0].jobs.length).toEqual(3);
+  });
+});

--- a/tests/Pipelines.test.ts
+++ b/tests/Pipelines.test.ts
@@ -40,7 +40,6 @@ describe('Check built-in pipeline parameters', () => {
 
 describe('Implement type-safe pipeline parameters', () => {
   const DockerExecutor = new CircleCI.Executor.DockerExecutor(
-    'dockerExecutor',
     'cimg/base:stable',
   );
   const myJob = new CircleCI.Job('myJob', DockerExecutor);

--- a/tests/Workflow.test.ts
+++ b/tests/Workflow.test.ts
@@ -2,10 +2,7 @@ import * as CircleCI from '../src/index';
 import * as YAML from 'yaml';
 
 describe('Instantiate Workflow', () => {
-  const docker = new CircleCI.Executor.DockerExecutor(
-    'docker-executor',
-    'cimg/node:lts',
-  );
+  const docker = new CircleCI.Executor.DockerExecutor('cimg/node:lts');
   const helloWorld = new CircleCI.Command.Run({
     command: 'echo hello world',
   });
@@ -22,10 +19,7 @@ describe('Instantiate Workflow', () => {
 });
 
 describe('Instantiate Workflow with a custom name', () => {
-  const docker = new CircleCI.Executor.DockerExecutor(
-    'docker-executor',
-    'cimg/node:lts',
-  );
+  const docker = new CircleCI.Executor.DockerExecutor('cimg/node:lts');
   const helloWorld = new CircleCI.Command.Run({
     command: 'echo hello world',
   });
@@ -42,10 +36,7 @@ describe('Instantiate Workflow with a custom name', () => {
 });
 
 describe('Utilize workflow job filters', () => {
-  const docker = new CircleCI.Executor.DockerExecutor(
-    'docker-executor',
-    'cimg/node:lts',
-  );
+  const docker = new CircleCI.Executor.DockerExecutor('cimg/node:lts');
   const helloWorld = new CircleCI.Command.Run({
     command: 'echo hello world',
   });
@@ -75,10 +66,7 @@ describe('Utilize workflow job filters', () => {
 });
 
 describe('Instantiate Workflow with a manual approval job', () => {
-  const docker = new CircleCI.Executor.DockerExecutor(
-    'docker-executor',
-    'cimg/node:lts',
-  );
+  const docker = new CircleCI.Executor.DockerExecutor('cimg/node:lts');
   const helloWorld = new CircleCI.Command.Run({
     command: 'echo hello world',
   });
@@ -107,10 +95,7 @@ describe('Instantiate Workflow with a manual approval job', () => {
 });
 
 describe('Instantiate a Workflow with sequential jobs', () => {
-  const docker = new CircleCI.Executor.DockerExecutor(
-    'docker-executor',
-    'cimg/node:lts',
-  );
+  const docker = new CircleCI.Executor.DockerExecutor('cimg/node:lts');
   const helloWorld = new CircleCI.Command.Run({
     command: 'echo hello world',
   });
@@ -131,7 +116,7 @@ describe('Instantiate a Workflow with sequential jobs', () => {
 });
 
 describe('Instantiate a Workflow with 2 jobs', () => {
-  const docker = new CircleCI.Executor.DockerExecutor('node', 'cimg/node:lts');
+  const docker = new CircleCI.Executor.DockerExecutor('cimg/node:lts');
   const helloWorld = new CircleCI.Command.Run({ command: 'echo hello world' });
   const jobA = new CircleCI.Job('my-job-A', docker, [helloWorld]);
   const jobB = new CircleCI.Job('my-job-B', docker, [helloWorld]);
@@ -150,10 +135,7 @@ describe('Instantiate a Workflow with 2 jobs', () => {
 });
 
 describe('Add a job to a workflow with a custom name parameter', () => {
-  const docker = new CircleCI.Executor.DockerExecutor(
-    'docker-executor',
-    'cimg/node:lts',
-  );
+  const docker = new CircleCI.Executor.DockerExecutor('cimg/node:lts');
   const helloWorld = new CircleCI.Command.Run({
     command: 'echo hello world',
   });

--- a/tests/WorkspacesExample.test.ts
+++ b/tests/WorkspacesExample.test.ts
@@ -5,11 +5,7 @@ describe('Generate a config utilizing Workspaces', () => {
   const myConfig = new CircleCI.Config();
 
   // Create a Docker-based Executor
-  const myExecutor = new CircleCI.Executor.DockerExecutor(
-    'my-executor',
-    'cimg/base:stable',
-  );
-  myConfig.addExecutor(myExecutor);
+  const myExecutor = new CircleCI.Executor.DockerExecutor('cimg/base:stable');
 
   // Create Jobs
   const jobFlow = new CircleCI.Job('flow', myExecutor, [
@@ -36,15 +32,10 @@ describe('Generate a config utilizing Workspaces', () => {
     const expectedConfig = {
       version: 2.1,
       setup: false,
-      executors: {
-        'my-executor': {
-          docker: [{ image: 'cimg/base:stable' }],
-          resource_class: 'medium',
-        },
-      },
       jobs: {
         flow: {
-          executor: { name: 'my-executor' },
+          docker: [{ image: 'cimg/base:stable' }],
+          resource_class: 'medium',
           steps: [
             {
               persist_to_workspace: {
@@ -55,7 +46,8 @@ describe('Generate a config utilizing Workspaces', () => {
           ],
         },
         downstream: {
-          executor: { name: 'my-executor' },
+          docker: [{ image: 'cimg/base:stable' }],
+          resource_class: 'medium',
           steps: [{ attach_workspace: { at: '/tmp/workspace' } }],
         },
       },


### PR DESCRIPTION
# Remove Reusable Executors

Reusable Executors are an abstraction added to CircleCI Config to emulate programmatic logic. Once CircleCI 2.1 code is processed on CircleCI `circleci config process`, the reusable executors are expanded and "duplicated" in place.

Removing Reusable Executors allows us to better customize our job creation, now allowing for patterns like Matrix jobs, where a job is dynamically created and added to the config. This is possible because the executor can be directly embedded.

Example from the test added that shows Matrix Jobs:

```typescript
// Generate a "Matrix" of Jobs with node executors, testing node versions: 13.0.0, 16.0.0, 18.0.0
describe('Generate 3 node-based jobs with different node versions', () => {
  const config = new CircleCI.Config();
  const nodeVersions = ['13.0.0', '16.0.0', '18.0.0'];
  const workflow = new CircleCI.Workflow('my-workflow');
  const helloWorld = new CircleCI.Command.Run({
    command: 'echo hello world',
  });

  nodeVersions.forEach((version) => {
    const docker = new CircleCI.Executor.DockerExecutor(`cimg/node:${version}`);
    const job = new CircleCI.Job(`test-${version}`, docker, [helloWorld]);
    config.addJob(job);
    workflow.addJob(job);
  });

  config.addWorkflow(workflow);

  it('The config should contain three jobs', () => {
    expect(config.jobs.length).toEqual(3);
  });
  it('The config workflow should contain three jobs', () => {
    expect(config.workflows[0].jobs.length).toEqual(3);
  });
});
```