### PR TITLE
ci: update orbs and node test matrix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 orbs:
   node: circleci/node@4.7
-  codecov: codecov/codecov@1.2
+  codecov: codecov/codecov@3.2
 
 commands:
   update-version:


### PR DESCRIPTION
1. Ensure all orbs are updated
2. Change the Node.js versions in the test matrix.
    - Included more test versions
    - Utilized "current" and "lts" aliases