### PR TITLE
Expose types from DockerImage

### DIFF
--- a/src/lib/Components/Executor/index.ts
+++ b/src/lib/Components/Executor/index.ts
@@ -5,3 +5,4 @@ export { DockerExecutor } from './DockerExecutor';
 export { MachineExecutor } from './MachineExecutor';
 export { MacOSExecutor } from './MacOSExecutor';
 export { WindowsExecutor } from './WindowsExecutor';
+export * from './DockerImage';


### PR DESCRIPTION
It's currently not possible to use DockerExecutor.serviceImages with TypeScript because the DockerImage class is not exposed. The interfaces are used by the public API of DockerImage, so those need to be exposed too. 