### PR TITLE
Refactor: Executor Generators and Config Generation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@circleci/circleci-config-sdk",
-  "version": "0.0.0-development",
+  "version": "0.6.0-alpha.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@circleci/circleci-config-sdk",
-      "version": "0.0.0-development",
+      "version": "0.6.0-alpha.1",
       "bundleDependencies": [
         "yaml"
       ],

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/circleci-config-sdk",
-  "version": "0.0.0-development",
+  "version": "0.6.0-alpha.1",
   "description": "An SDK for building CircleCI Configuration files with JavaScript.",
   "main": "dist/circleci-config-sdk.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@circleci/circleci-config-sdk",
-  "version": "0.6.0-alpha.1",
+  "version": "0.0.0-development",
   "description": "An SDK for building CircleCI Configuration files with JavaScript.",
   "main": "dist/circleci-config-sdk.js",
   "types": "dist/src/index.d.ts",

--- a/src/lib/Components/Executors/exports/Executor.ts
+++ b/src/lib/Components/Executors/exports/Executor.ts
@@ -18,6 +18,6 @@ export abstract class Executor implements Generable {
     this.resource_class = resource_class;
     this.parameters = parameters;
   }
-  abstract generate(): ExecutorShape;
+  abstract generate(ctx?: GenerableType): ExecutorShape;
   abstract get generableType(): GenerableType;
 }

--- a/src/lib/Components/Executors/exports/ReusableExecutor.ts
+++ b/src/lib/Components/Executors/exports/ReusableExecutor.ts
@@ -3,7 +3,10 @@ import { GenerableType } from '../../../Config/exports/Mapping';
 import { CustomParametersList } from '../../Parameters';
 import { Parameterized } from '../../Parameters/exports/Parameterized';
 import { ExecutorParameterLiteral } from '../../Parameters/types/CustomParameterLiterals.types';
-import { ReusableExecutorShape } from '../types/ReusableExecutor.types';
+import {
+  ReusableExecutorJobRefShape,
+  ReusableExecutorShape,
+} from '../types/ReusableExecutor.types';
 import { Executor } from './Executor';
 /**
  * A 2.1 wrapper for reusing CircleCI executor.
@@ -41,10 +44,28 @@ export class ReusableExecutor
    * Generate Reusable Executor schema.
    * @returns The generated JSON for the Reusable Executor.
    */
-  generate(): ReusableExecutorShape {
+  generate(
+    ctx?: GenerableType,
+  ): ReusableExecutorShape | ReusableExecutorJobRefShape {
+    if (ctx == GenerableType.JOB) {
+      // TODO: Enable for 'minification'
+      // if (!this.parameters) {
+      //   return {
+      //     executor: this.name;
+      //   }
+      // }
+
+      return {
+        executor: {
+          name: this.name,
+        },
+      };
+    }
+
     return {
-      executor: {
-        name: this.name,
+      [this.name]: {
+        ...this.executor.generate(),
+        parameters: this.parameters?.generate(),
       },
     };
   }

--- a/src/lib/Components/Executors/types/Executor.types.ts
+++ b/src/lib/Components/Executors/types/Executor.types.ts
@@ -1,7 +1,6 @@
 import { DockerExecutorShape } from './DockerExecutor.types';
 import { MachineExecutorShape } from './MachineExecutor.types';
 import { MacOSExecutorShape } from './MacOSExecutor.types';
-import { ReusableExecutorShape } from './ReusableExecutor.types';
 import { WindowsExecutorShape } from './WindowsExecutor.types';
 
 export type UnknownExecutorShape = {
@@ -16,8 +15,7 @@ export type ExecutorShape =
   | DockerExecutorShape
   | MachineExecutorShape
   | MacOSExecutorShape
-  | WindowsExecutorShape
-  | ReusableExecutorShape;
+  | WindowsExecutorShape;
 
 /**
  * The valid resource classes found for an executor object

--- a/src/lib/Components/Executors/types/ReusableExecutor.types.ts
+++ b/src/lib/Components/Executors/types/ReusableExecutor.types.ts
@@ -1,13 +1,22 @@
-import { AnyParameterType, StringParameter } from '../../Parameters/types';
+import {
+  AnyParameterType,
+  CustomParametersListShape,
+  StringParameter,
+} from '../../Parameters/types';
 import { ExecutorShape } from './Executor.types';
 
-export interface ReusableExecutorShape {
+/**
+ * The shape output when a reusable executor is generated for a job
+ */
+export type ReusableExecutorJobRefShape = {
   executor: {
     name: StringParameter;
     [key: string]: AnyParameterType;
   };
-}
+};
 
-export interface ReusableExecutorsShape {
-  [key: string]: ExecutorShape;
-}
+export type ReusableExecutorShape = {
+  [key: string]: ExecutorShape & {
+    parameters?: CustomParametersListShape;
+  };
+};

--- a/src/lib/Components/Job/index.ts
+++ b/src/lib/Components/Job/index.ts
@@ -1,9 +1,9 @@
-import { ParameterizedJob } from './exports/ParameterizedJob';
 import { GenerableType } from '../../Config/exports/Mapping';
 import { Command } from '../Commands/exports/Command';
 import { ExecutorShape } from '../Executors/types/Executor.types';
 import { Generable } from '../index';
-import { AnyExecutor, JobContentsShape, JobShape } from './types/Job.types';
+import { ParameterizedJob } from './exports/ParameterizedJob';
+import { AnyExecutor, JobContentsShape, JobsShape } from './types/Job.types';
 
 /**
  * Jobs define a collection of steps to be run within a given executor, and are orchestrated using Workflows.
@@ -42,7 +42,9 @@ export class Job implements Generable {
     const generatedSteps = this.steps.map((step) => {
       return step.generate();
     });
-    const generatedExecutor = this.executor.generate() as ExecutorShape;
+    const generatedExecutor = this.executor.generate(
+      GenerableType.JOB,
+    ) as ExecutorShape;
 
     return { steps: generatedSteps, ...generatedExecutor };
   }
@@ -50,7 +52,7 @@ export class Job implements Generable {
    * Generate Job schema
    * @returns The generated JSON for the Job.
    */
-  generate(): JobShape {
+  generate(): JobsShape {
     return {
       [this.name]: this.generateContents(),
     };

--- a/src/lib/Components/Job/types/Job.types.ts
+++ b/src/lib/Components/Job/types/Job.types.ts
@@ -9,7 +9,7 @@ export interface JobStepsShape {
 
 export type JobContentsShape = JobStepsShape & ExecutorShape;
 
-export interface JobShape {
+export interface JobsShape {
   [key: string]: JobContentsShape;
 }
 

--- a/src/lib/Components/Workflow/index.ts
+++ b/src/lib/Components/Workflow/index.ts
@@ -1,3 +1,5 @@
+import { Generable } from '..';
+import { GenerableType } from '../../Config/exports/Mapping';
 import { Job } from '../Job';
 import { WorkflowJob } from './exports/WorkflowJob';
 import { WorkflowShape } from './types/Workflow.types';
@@ -9,7 +11,7 @@ import {
 /**
  * A workflow is a set of rules for defining a collection of jobs and their run order.
  */
-export class Workflow {
+export class Workflow implements Generable {
   /**
    * The name of the Workflow.
    */
@@ -54,6 +56,10 @@ export class Workflow {
   addJob(job: Job, parameters?: WorkflowJobParameters): this {
     this.jobs.push(new WorkflowJob(job, parameters));
     return this;
+  }
+
+  get generableType(): GenerableType {
+    return GenerableType.WORKFLOW;
   }
 }
 

--- a/src/lib/Components/index.ts
+++ b/src/lib/Components/index.ts
@@ -8,7 +8,7 @@ export interface Generable {
    * Generate the CircleCI YAML equivalent JSON for config compilation
    * Generable's name is the key in the output.
    */
-  generate(): unknown;
+  generate(ctx?: GenerableType): unknown;
 
   /**
    * Generate the CircleCI YAML equivalent JSON contents for config compilation

--- a/src/lib/Config/types/index.ts
+++ b/src/lib/Config/types/index.ts
@@ -1,14 +1,14 @@
 import { CustomCommandShape } from '../../Components/Commands/types/Command.types';
-import { ReusableExecutorsShape } from '../../Components/Executors/types/ReusableExecutor.types';
-import { Job } from '../../Components/Job';
-import { JobShape } from '../../Components/Job/types/Job.types';
-import { ParameterShape } from '../../Components/Parameters/types';
-import { WorkflowShape } from '../../Components/Workflow/types/Workflow.types';
-import { Workflow } from '../../Components/Workflow';
-import * as validator from './Validator.types';
-import * as mapping from './Mapping.types';
-import { CustomCommand } from '../../Components/Reusable';
 import { ReusableExecutor } from '../../Components/Executors/exports/ReusableExecutor';
+import { ReusableExecutorShape } from '../../Components/Executors/types/ReusableExecutor.types';
+import { Job } from '../../Components/Job';
+import { JobsShape } from '../../Components/Job/types/Job.types';
+import { ParameterShape } from '../../Components/Parameters/types';
+import { CustomCommand } from '../../Components/Reusable';
+import { Workflow } from '../../Components/Workflow';
+import { WorkflowShape } from '../../Components/Workflow/types/Workflow.types';
+import * as mapping from './Mapping.types';
+import * as validator from './Validator.types';
 
 /**
  * Selected config version
@@ -41,9 +41,9 @@ export type CircleCIConfigShape = {
   version: ConfigVersion;
   setup: boolean;
   parameters?: Record<string, ParameterShape>;
-  executors?: ReusableExecutorsShape;
+  executors?: ReusableExecutorShape;
   orbs?: ConfigOrbImport[];
-  jobs: JobShape;
+  jobs: JobsShape;
   commands?: CustomCommandShape;
   workflows: WorkflowShape;
 };

--- a/tests/Executor.test.ts
+++ b/tests/Executor.test.ts
@@ -1,5 +1,6 @@
 import * as YAML from 'yaml';
 import * as CircleCI from '../src/index';
+import { GenerableType } from '../src/lib/Config/exports/Mapping';
 
 describe('Instantiate Docker Executor', () => {
   const docker = new CircleCI.executors.DockerExecutor('cimg/node:lts');
@@ -315,10 +316,22 @@ describe('Generate a config with a Reusable Executor with parameters', () => {
   const machine = new CircleCI.executors.MachineExecutor('large');
   const reusable = new CircleCI.reusable.ReusableExecutor('default', machine);
 
-  it('Should match the expected output', () => {
+  it('Should match the expected output in job context', () => {
     const expectedShape = {
       executor: {
         name: 'default',
+      },
+    };
+    expect(reusable.generate(GenerableType.JOB)).toEqual(expectedShape);
+  });
+
+  it('Should match the expected output with no context', () => {
+    const expectedShape = {
+      default: {
+        machine: {
+          image: 'ubuntu-2004:202010-01',
+        },
+        resource_class: 'large',
       },
     };
     expect(reusable.generate()).toEqual(expectedShape);


### PR DESCRIPTION
Config stringify method is much cleaner now.

ReusableExecutors now uses one contextual generate function rather than being done manually by the config.