### PR TITLE
feat: Support for shorthand run command.

### DIFF
--- a/src/lib/Components/Commands/exports/Command.ts
+++ b/src/lib/Components/Commands/exports/Command.ts
@@ -1,6 +1,10 @@
 import { Generable } from '../../index';
 import { StringParameter } from '../../Parameters/types';
-import { CommandParameters, CommandShape } from '../types/Command.types';
+import {
+  CommandParameters,
+  CommandShape,
+  CommandShorthandShape,
+} from '../types/Command.types';
 
 /**
  * Abstract - A generic Command
@@ -8,5 +12,5 @@ import { CommandParameters, CommandShape } from '../types/Command.types';
 export interface Command extends Generable {
   name: StringParameter;
   parameters?: CommandParameters;
-  generate(): CommandShape;
+  generate(): CommandShape | CommandShorthandShape;
 }

--- a/src/lib/Components/Commands/exports/Native/Run.ts
+++ b/src/lib/Components/Commands/exports/Native/Run.ts
@@ -4,7 +4,11 @@ import {
   EnvironmentParameter,
   StringParameter,
 } from '../../../Parameters/types';
-import { CommandParameters, CommandShape } from '../../types/Command.types';
+import {
+  CommandParameters,
+  CommandShape,
+  CommandShorthandShape,
+} from '../../types/Command.types';
 import { Command } from '../Command';
 
 /**
@@ -20,7 +24,13 @@ export class Run implements Command {
    * Generate Run Command shape.
    * @returns The generated JSON for the Run Commands.
    */
-  generate(): RunCommandShape {
+  generate(): RunCommandShape | RunCommandShorthandShape {
+    const { command, ...parameters } = this.parameters;
+
+    if (Object.keys(parameters).length === 0) {
+      return { run: command } as RunCommandShorthandShape;
+    }
+
     return { run: this.parameters } as RunCommandShape;
   }
 
@@ -72,4 +82,8 @@ export interface RunParameters extends CommandParameters {
  */
 export interface RunCommandShape extends CommandShape {
   run: RunParameters;
+}
+
+export interface RunCommandShorthandShape extends CommandShorthandShape {
+  run: string;
 }

--- a/src/lib/Components/Commands/exports/Reusable/CustomCommand.ts
+++ b/src/lib/Components/Commands/exports/Reusable/CustomCommand.ts
@@ -3,7 +3,7 @@ import { GenerableType } from '../../../../Config/exports/Mapping';
 import { CustomParametersList } from '../../../Parameters';
 import { Parameterized } from '../../../Parameters/exports/Parameterized';
 import { CommandParameterLiteral } from '../../../Parameters/types/CustomParameterLiterals.types';
-import { CommandShape, CustomCommandShape } from '../../types/Command.types';
+import { AnyCommandShape, CustomCommandShape } from '../../types/Command.types';
 import { Command } from '../Command';
 
 /**
@@ -44,7 +44,7 @@ export class CustomCommand
   }
 
   generate(): CustomCommandShape {
-    const generatedSteps: CommandShape[] = this.steps.map((step) =>
+    const generatedSteps: AnyCommandShape[] = this.steps.map((step) =>
       step.generate(),
     );
 

--- a/src/lib/Components/Commands/parsers/index.ts
+++ b/src/lib/Components/Commands/parsers/index.ts
@@ -86,6 +86,10 @@ const nativeSubtypes: {
     const runArgs = args as RunParameters;
 
     if (Validator.validateGenerable(GenerableType.RUN, runArgs)) {
+      if (typeof args === 'string') {
+        return new Run({ command: args });
+      }
+
       return new Run(args as RunParameters);
     }
   },

--- a/src/lib/Components/Commands/types/Command.types.ts
+++ b/src/lib/Components/Commands/types/Command.types.ts
@@ -13,9 +13,13 @@ export type CommandParameters = ComponentParameter<CommandParameterTypes>;
 
 export type CommandShape = Record<string, CommandParameters>;
 
+export type CommandShorthandShape = Record<string, string>;
+
+export type AnyCommandShape = CommandShape | CommandShorthandShape;
+
 export type CustomCommandBodyShape = {
   parameters?: CustomParametersListShape;
-  steps: CommandShape[];
+  steps: AnyCommandShape[];
   description?: string;
 };
 

--- a/tests/Commands.test.ts
+++ b/tests/Commands.test.ts
@@ -16,8 +16,7 @@ describe('Instantiate a Run step', () => {
     command: 'echo hello world',
   });
   const runStep = run.generate();
-  // TODO: Add support for: { run: 'echo hello world' };
-  const expectedResult = { run: { command: 'echo hello world' } };
+  const expectedResult = { run: 'echo hello world' };
   it('Should generate checkout yaml', () => {
     expect(runStep).toEqual(expectedResult);
   });
@@ -177,11 +176,16 @@ describe('Add SSH Keys', () => {
 
 describe('Instantiate a Blank Custom Command', () => {
   const customCommand = new CircleCI.reusable.CustomCommand('say_hello', [
-    new CircleCI.commands.Run({ command: 'echo "Hello, World!"' }),
+    new CircleCI.commands.Run({
+      command: 'echo "Hello, World!"',
+      name: 'Say hello!',
+    }),
   ]);
 
   const example = {
-    say_hello: { steps: [{ run: { command: 'echo "Hello, World!"' } }] },
+    say_hello: {
+      steps: [{ run: { command: 'echo "Hello, World!"', name: 'Say hello!' } }],
+    },
   };
 
   it('Should generate checkout yaml', () => {
@@ -211,8 +215,7 @@ describe('Instantiate a Custom Command', () => {
       type: string
       default: hello world
   steps:
-    - run:
-        command: echo << parameters.greeting >>`;
+    - run: echo << parameters.greeting >>`;
 
   it('Should generate checkout yaml', () => {
     expect(customCommand.generate()).toEqual(parse(expectedOutput));
@@ -275,8 +278,7 @@ describe('Instantiate reusable commands', () => {
         type: integer
         default: 90
     steps:
-      - run:
-          command: echo << parameters.axis >>`;
+      - run: echo << parameters.axis >>`;
 
     expect(firstCustomCommand.generate()).toEqual(parse(firstExpectedOutput));
   });
@@ -303,8 +305,7 @@ describe('Instantiate reusable commands', () => {
       year:
         type: integer
     steps:
-      - run:
-          command: echo << parameters.year >>`;
+      - run: echo << parameters.year >>`;
 
     expect(secondCustomCommand.generate()).toEqual(parse(secondExpectedOutput));
   });
@@ -461,12 +462,11 @@ echo "hello world 2"
 echo "hello world 3"
 echo hello world 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 this string is a single line, and should output as a single line`,
   });
-  const expectedOutput = `run:
-  command: |-
-    echo "hello world 1"
-    echo "hello world 2"
-    echo "hello world 3"
-    echo hello world 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 this string is a single line, and should output as a single line
+  const expectedOutput = `run: |-
+  echo "hello world 1"
+  echo "hello world 2"
+  echo "hello world 3"
+  echo hello world 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 this string is a single line, and should output as a single line
 `;
   it('Should match expectedOutput', () => {
     expect(stringify(multiLineCommand.generate(), stringifyOptions)).toEqual(
@@ -480,8 +480,7 @@ describe('Instantiate a Run command with 70 characters in the command string and
   const longCommand = new CircleCI.commands.Run({
     command: `echo hello world 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 this string is a single line, and should output as a single line`,
   });
-  const expectedOutput = `run:
-  command: echo hello world 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 this string is a single line, and should output as a single line
+  const expectedOutput = `run: echo hello world 1 2 3 4 5 6 7 8 9 0 1 2 3 4 5 6 7 8 9 0 this string is a single line, and should output as a single line
 `;
   it('Should match expectedOutput', () => {
     expect(stringify(longCommand.generate(), stringifyOptions)).toEqual(

--- a/tests/Job.test.ts
+++ b/tests/Job.test.ts
@@ -11,7 +11,7 @@ describe('Instantiate Docker Job', () => {
   const jobContents = {
     docker: [{ image: 'cimg/node:lts' }],
     resource_class: 'medium',
-    steps: [{ run: { command: 'echo hello world' } }],
+    steps: [{ run: 'echo hello world' }],
   };
 
   it('Should match the expected output', () => {
@@ -48,8 +48,7 @@ describe('Instantiate Parameterized Docker Job With Custom Parameters', () => {
     - image: cimg/node:lts
   resource_class: medium
   steps:
-    - run:
-        command: echo << parameters.greeting >>`;
+    - run: echo << parameters.greeting >>`;
 
   it('Should match the expected output', () => {
     expect(job.generate()).toEqual(YAML.parse(expectedOutput));
@@ -103,9 +102,7 @@ describe('Instantiate Parameterized Docker Job With A Custom Command', () => {
         },
         steps: [
           {
-            run: {
-              command: 'echo << parameters.greeting >>',
-            },
+            run: 'echo << parameters.greeting >>',
           },
         ],
       },


### PR DESCRIPTION
Previously, `run: $command` was not able to be parsed. It is now supported.