### PR TITLE
feat: Reuse Executors Definintions with Properties

### DIFF
--- a/src/lib/Components/Executors/exports/Executor.ts
+++ b/src/lib/Components/Executors/exports/Executor.ts
@@ -1,11 +1,14 @@
 import { GenerableType } from '../../../Config/exports/Mapping';
 import { Generable } from '../../index';
+import { CustomParametersList } from '../../Parameters';
+import { ExecutorParameterLiteral } from '../../Parameters/types/CustomParameterLiterals.types';
 import {
   AnyResourceClass,
   ExecutorLiteral,
   ExecutorShape,
 } from '../types/Executor.types';
 import { ExecutableParameters } from '../types/ExecutorParameters.types';
+import { ReusableExecutor } from './ReusableExecutor';
 
 /**
  * A generic reusable Executor
@@ -41,5 +44,12 @@ export abstract class Executor<
       resource_class: this.generateResourceClass,
       ...this.parameters,
     };
+  }
+
+  asReusable(
+    name: string,
+    parameters?: CustomParametersList<ExecutorParameterLiteral>,
+  ): ReusableExecutor {
+    return new ReusableExecutor(name, this, parameters);
   }
 }

--- a/src/lib/Components/Executors/exports/ReusableExecutor.ts
+++ b/src/lib/Components/Executors/exports/ReusableExecutor.ts
@@ -2,12 +2,14 @@ import { Generable } from '../..';
 import { GenerableType } from '../../../Config/exports/Mapping';
 import { CustomParametersList } from '../../Parameters';
 import { Parameterized } from '../../Parameters/exports/Parameterized';
+import { ExecutorParameterTypes } from '../../Parameters/types/ComponentParameters.types';
 import { ExecutorParameterLiteral } from '../../Parameters/types/CustomParameterLiterals.types';
 import {
   ReusableExecutorJobRefShape,
   ReusableExecutorsShape,
 } from '../types/ReusableExecutor.types';
 import { Executor } from './Executor';
+import { ReusedExecutor } from './ReusedExecutor';
 /**
  * A 2.1 wrapper for reusing CircleCI executor.
  * @see {@link https://circleci.com/docs/2.0/reusing-config/#the-executors-key}
@@ -88,5 +90,9 @@ export class ReusableExecutor
 
   get generableType(): GenerableType {
     return GenerableType.REUSABLE_EXECUTOR;
+  }
+
+  reuse(parameters?: Record<string, ExecutorParameterTypes>): ReusedExecutor {
+    return new ReusedExecutor(this, parameters);
   }
 }

--- a/src/lib/Components/Executors/exports/ReusedExecutor.ts
+++ b/src/lib/Components/Executors/exports/ReusedExecutor.ts
@@ -43,7 +43,7 @@ export class ReusedExecutor implements Generable {
    * @returns The generated JSON for the Reused Executor.
    */
   generateContents(): ReusedExecutorShapeContents {
-    if (this._executor.parameters) {
+    if (this._parameters) {
       return {
         name: this._executor.name,
         ...this._parameters,

--- a/src/lib/Components/Executors/exports/ReusedExecutor.ts
+++ b/src/lib/Components/Executors/exports/ReusedExecutor.ts
@@ -1,0 +1,67 @@
+import { Generable } from '../..';
+import { GenerableType } from '../../../Config/exports/Mapping';
+import { ExecutorParameterTypes } from '../../Parameters/types/ComponentParameters.types';
+import {
+  ReusedExecutorShape,
+  ReusedExecutorShapeContents,
+} from '../types/ReusableExecutor.types';
+import { ReusableExecutor } from './ReusableExecutor';
+/**
+ * A 2.1 wrapper for reusing CircleCI executor.
+ * @see {@link https://circleci.com/docs/2.0/reusing-config/#the-executors-key}
+ * {@label STATIC_2.1}
+ */
+export class ReusedExecutor implements Generable {
+  /**
+   * The referenced executor to use.
+   */
+  private _executor: ReusableExecutor;
+
+  /**
+   * Parameters to assign to the executor
+   */
+  private _parameters?: Record<string, ExecutorParameterTypes>;
+
+  constructor(
+    executor: ReusableExecutor,
+    parameters?: Record<string, ExecutorParameterTypes>,
+  ) {
+    this._executor = executor;
+    this._parameters = parameters;
+  }
+  /**
+   * Generate Reused Executor schema.
+   * @returns The generated JSON for the Reused Executor.
+   */
+  generate(): ReusedExecutorShape {
+    return {
+      executor: this.generateContents(),
+    };
+  }
+  /**
+   * Generate Reused Executor schema.
+   * @returns The generated JSON for the Reused Executor.
+   */
+  generateContents(): ReusedExecutorShapeContents {
+    if (this._executor.parameters) {
+      return {
+        name: this._executor.name,
+        ...this._parameters,
+      };
+    }
+
+    return this._executor.name;
+  }
+
+  get generableType(): GenerableType {
+    return GenerableType.REUSED_EXECUTOR;
+  }
+
+  get executor(): ReusableExecutor {
+    return this._executor;
+  }
+
+  get parameters(): Record<string, ExecutorParameterTypes> | undefined {
+    return this._parameters;
+  }
+}

--- a/src/lib/Components/Executors/parsers/index.ts
+++ b/src/lib/Components/Executors/parsers/index.ts
@@ -105,7 +105,7 @@ const subtypeParsers: ExecutorSubtypeMap = {
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { name, ...parsedParameters } = executorArgs;
 
-        if (Object.values(parsedParameters).length !== 0) {
+        if (Object.values(parsedParameters).length > 0) {
           parameters = parsedParameters as
             | Record<string, ExecutorParameterTypes>
             | undefined;

--- a/src/lib/Components/Executors/parsers/index.ts
+++ b/src/lib/Components/Executors/parsers/index.ts
@@ -104,9 +104,12 @@ const subtypeParsers: ExecutorSubtypeMap = {
         // destructure and ignore the name.
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
         const { name, ...parsedParameters } = executorArgs;
-        parameters = parsedParameters as
-          | Record<string, ExecutorParameterTypes>
-          | undefined;
+
+        if (Object.values(parsedParameters).length !== 0) {
+          parameters = parsedParameters as
+            | Record<string, ExecutorParameterTypes>
+            | undefined;
+        }
       }
 
       return executor.reuse(parameters);

--- a/src/lib/Components/Executors/parsers/index.ts
+++ b/src/lib/Components/Executors/parsers/index.ts
@@ -3,8 +3,10 @@ import {
   ParameterizedComponent,
 } from '../../../Config/exports/Mapping';
 import { errorParsing, parseGenerable } from '../../../Config/exports/Parsing';
+import { AnyExecutor } from '../../Job/types/Job.types';
 import { CustomParametersList } from '../../Parameters';
 import { parseParameterList } from '../../Parameters/parsers';
+import { ExecutorParameterTypes } from '../../Parameters/types/ComponentParameters.types';
 import { ExecutorParameterLiteral } from '../../Parameters/types/CustomParameterLiterals.types';
 import { DockerExecutor } from '../exports/DockerExecutor';
 import { Executor } from '../exports/Executor';
@@ -79,14 +81,14 @@ const subtypeParsers: ExecutorSubtypeMap = {
   },
   // Parses a reusable executor by it's name
   executor: {
-    generableType: GenerableType.ANY_EXECUTOR,
+    generableType: GenerableType.REUSED_EXECUTOR,
     parse: (args, _, __, reusableExecutors) => {
       const executorArgs = args as
         | { name: string; [key: string]: unknown }
         | string;
 
-      const name =
-        typeof executorArgs === 'string' ? executorArgs : executorArgs.name;
+      const isFlat = typeof executorArgs === 'string';
+      const name = isFlat ? executorArgs : executorArgs.name;
 
       const executor = reusableExecutors?.find(
         (executor) => executor.name === name,
@@ -96,7 +98,18 @@ const subtypeParsers: ExecutorSubtypeMap = {
         throw errorParsing(`Reusable executor ${name} not found in config`);
       }
 
-      return executor;
+      let parameters = undefined;
+
+      if (!isFlat) {
+        // destructure and ignore the name.
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        const { name, ...parsedParameters } = executorArgs;
+        parameters = parsedParameters as
+          | Record<string, ExecutorParameterTypes>
+          | undefined;
+      }
+
+      return executor.reuse(parameters);
     },
   },
 };
@@ -135,7 +148,7 @@ export function extractExecutableProps(
 export function parseExecutor(
   executableIn: unknown,
   reusableExecutors?: ReusableExecutor[],
-): Executor | ReusableExecutor {
+): AnyExecutor {
   const executableArgs = executableIn as UnknownExecutableShape;
   let resourceClass = executableArgs.resource_class;
   let executorType: ExecutorUsageLiteral | 'windows' | undefined;
@@ -160,7 +173,7 @@ export function parseExecutor(
 
   const { generableType, parse } = subtypeParsers[executorType || executorKey];
 
-  return parseGenerable<UnknownExecutableShape, Executor | ReusableExecutor>(
+  return parseGenerable<UnknownExecutableShape, AnyExecutor>(
     generableType,
     executableArgs,
     (args) => {

--- a/src/lib/Components/Executors/schemas/ReusableExecutable.schema.ts
+++ b/src/lib/Components/Executors/schemas/ReusableExecutable.schema.ts
@@ -8,7 +8,6 @@ export const ReusableExecutorUsageSchema: SchemaObject = {
       properties: {
         executor: { type: 'string' },
       },
-      additionalProperties: false,
     },
     {
       properties: {
@@ -18,7 +17,6 @@ export const ReusableExecutorUsageSchema: SchemaObject = {
             name: { type: 'string' },
           },
         },
-        additionalProperties: false,
       },
     },
   ],

--- a/src/lib/Components/Executors/types/Executor.types.ts
+++ b/src/lib/Components/Executors/types/Executor.types.ts
@@ -1,9 +1,11 @@
 import { GenerableType } from '../../../Config/exports/Mapping';
+import { AnyExecutor } from '../../Job/types/Job.types';
 import { CustomParametersList } from '../../Parameters';
 import { ExecutorParameterLiteral } from '../../Parameters/types/CustomParameterLiterals.types';
 import { Executor } from '../exports/Executor';
 import { ReusableExecutor } from '../exports/ReusableExecutor';
 import { ExecutableProperties } from './ExecutorParameters.types';
+import { ReusedExecutorShape } from './ReusableExecutor.types';
 
 export type UnknownExecutableShape = {
   resource_class: AnyResourceClass;
@@ -17,6 +19,8 @@ export type ExecutorShape = {
   resource_class: string;
 } & Partial<Record<ExecutorLiteral, unknown>> &
   ExecutableProperties;
+
+export type AnyExecutorShape = ExecutorShape | ReusedExecutorShape;
 
 /**
  * The valid resource classes found for an executor object
@@ -66,4 +70,4 @@ export type ExecutorSubtypeParser = (
   resourceClass: AnyResourceClass,
   properties?: ExecutableProperties,
   reusableExecutors?: ReusableExecutor[],
-) => Executor | ReusableExecutor;
+) => AnyExecutor;

--- a/src/lib/Components/Executors/types/ReusableExecutor.types.ts
+++ b/src/lib/Components/Executors/types/ReusableExecutor.types.ts
@@ -20,3 +20,20 @@ export type ReusableExecutorsShape = {
     parameters?: CustomParametersListShape;
   };
 };
+
+/**
+ * The shape output when a reusable executor is generated for a job
+ */
+export type ReusedExecutorShapeContents =
+  | {
+      name: StringParameter;
+      [key: string]: AnyParameterType;
+    }
+  | StringParameter;
+
+/**
+ * The shape output when a reusable executor is generated for a job
+ */
+export type ReusedExecutorShape = {
+  executor: ReusedExecutorShapeContents;
+};

--- a/src/lib/Components/Job/index.ts
+++ b/src/lib/Components/Job/index.ts
@@ -1,6 +1,5 @@
 import { GenerableType } from '../../Config/exports/Mapping';
 import { Command } from '../Commands/exports/Command';
-import { ExecutorShape } from '../Executors/types/Executor.types';
 import { Generable } from '../index';
 import { AnyExecutor, JobContentsShape, JobsShape } from './types/Job.types';
 
@@ -41,9 +40,7 @@ export class Job implements Generable {
     const generatedSteps = this.steps.map((step) => {
       return step.generate();
     });
-    const generatedExecutor = this.executor.generate(
-      this.generableType,
-    ) as ExecutorShape;
+    const generatedExecutor = this.executor.generate();
 
     return { steps: generatedSteps, ...generatedExecutor };
   }

--- a/src/lib/Components/Job/types/Job.types.ts
+++ b/src/lib/Components/Job/types/Job.types.ts
@@ -1,29 +1,29 @@
 import { Command } from '../../Commands/exports/Command';
 import { Executor } from '../../Executors';
-import { ExecutorShape } from '../../Executors/types/Executor.types';
+import { ReusedExecutor } from '../../Executors/exports/ReusedExecutor';
+import { AnyExecutorShape } from '../../Executors/types/Executor.types';
 import { CustomParametersList } from '../../Parameters';
 import { CustomParametersListShape } from '../../Parameters/types';
 import { JobParameterLiteral } from '../../Parameters/types/CustomParameterLiterals.types';
-import { ReusableExecutor } from '../../Reusable';
 
 export type JobStepsShape = {
   steps: unknown[]; // CommandSchemas for any command.
 };
 
-export type JobContentsShape = JobStepsShape & ExecutorShape;
+export type JobContentsShape = JobStepsShape & AnyExecutorShape;
 
 export type JobsShape = {
   [key: string]: JobContentsShape;
 };
 
-export type AnyExecutor = ReusableExecutor | Executor;
+export type AnyExecutor = ReusedExecutor | Executor;
 
 export type ParameterizedJobContents = JobContentsShape & {
   parameters: CustomParametersListShape;
 };
 
 export type JobDependencies = {
-  executor: Executor | ReusableExecutor;
+  executor: AnyExecutor;
   steps: Command[];
   parametersList?: CustomParametersList<JobParameterLiteral>;
 };

--- a/src/lib/Config/exports/Mapping.ts
+++ b/src/lib/Config/exports/Mapping.ts
@@ -28,7 +28,7 @@ export enum GenerableType {
   MACHINE_EXECUTOR = 'machine_executor',
   MACOS_EXECUTOR = 'macos_executor',
   WINDOWS_EXECUTOR = 'windows_executor',
-  REUSABLE_EXECUTOR_USAGE = 'reusable_executor_usage',
+  REUSED_EXECUTOR = 'reused_executor',
   REUSABLE_EXECUTOR = 'reusable_executor',
   REUSABLE_EXECUTOR_LIST = 'reusable_executors_list',
 

--- a/src/lib/Config/exports/Validator.ts
+++ b/src/lib/Config/exports/Validator.ts
@@ -80,7 +80,7 @@ const schemaRegistry: ValidationMap = {
   [GenerableType.WINDOWS_EXECUTOR]: WindowsExecutableSchema,
   [GenerableType.REUSABLE_EXECUTOR]: ReusableExecutorSchema,
   [GenerableType.REUSABLE_EXECUTOR_LIST]: ReusableExecutorsListSchema,
-  [GenerableType.REUSABLE_EXECUTOR_USAGE]: ReusableExecutorUsageSchema,
+  [GenerableType.REUSED_EXECUTOR]: ReusableExecutorUsageSchema,
 
   [GenerableType.STEP]: StepSchema,
   [GenerableType.STEP_LIST]: StepsSchema,

--- a/src/lib/Config/index.ts
+++ b/src/lib/Config/index.ts
@@ -187,13 +187,6 @@ export class Config
       workflows: generatedWorkflows,
     };
 
-    // remove undefined values
-    Object.entries(generatedConfig).forEach(([key, value]) => {
-      if (value === undefined) {
-        delete generatedConfig[key as keyof CircleCIConfigShape];
-      }
-    });
-
     return this.prependVersionComment(
       stringify(generatedConfig as CircleCIConfigShape, {
         defaultStringType: Scalar.PLAIN,

--- a/tests/Config.test.ts
+++ b/tests/Config.test.ts
@@ -1,11 +1,11 @@
-import * as CircleCI from '../src/index';
 import * as YAML from 'yaml';
-import { version as SDKVersion } from '../src/package-version.json';
+import * as CircleCI from '../src/index';
+import { GenerableType } from '../src/lib/Config/exports/Mapping';
 import {
   parseGenerable,
   setLogParsing,
 } from '../src/lib/Config/exports/Parsing';
-import { GenerableType } from '../src/lib/Config/exports/Mapping';
+import { version as SDKVersion } from '../src/package-version.json';
 
 describe('Generate a Setup workflow config', () => {
   const myConfig = new CircleCI.Config(true).generate();
@@ -63,12 +63,15 @@ describe('Parse a fully complete config', () => {
 
   myConfig.defineParameter('greeting', 'string', 'hello world!');
 
-  const docker = new CircleCI.executors.DockerExecutor('cimg/node:lts');
+  const docker = new CircleCI.executors.DockerExecutor(
+    'cimg/node:<< parameters.version >>',
+  );
   const reusableDocker = new CircleCI.reusable.ReusableExecutor(
     'docker',
     docker,
   );
 
+  reusableDocker.defineParameter('version', 'string', '16.3');
   myConfig.addReusableExecutor(reusableDocker);
 
   const customCommand = new CircleCI.reusable.CustomCommand(
@@ -85,12 +88,12 @@ describe('Parse a fully complete config', () => {
 
   myConfig.addCustomCommand(customCommand);
 
-  const jobA = new CircleCI.Job('my-job-A', reusableDocker, [
+  const jobA = new CircleCI.Job('my-job-A', reusableDocker.reuse(), [
     new CircleCI.reusable.ReusableCommand(customCommand, {
       greeting: '<< pipeline.parameters.greeting >>',
     }),
   ]);
-  const jobB = new CircleCI.Job('my-job-B', reusableDocker, [
+  const jobB = new CircleCI.Job('my-job-B', reusableDocker.reuse(), [
     new CircleCI.reusable.ReusableCommand(customCommand, {
       greeting: 'sup world!',
     }),
@@ -133,7 +136,13 @@ describe('Parse a fully complete config', () => {
     },
     executors: {
       docker: {
-        docker: [{ image: 'cimg/node:lts' }],
+        docker: [{ image: 'cimg/node:<< parameters.version >>' }],
+        parameters: {
+          version: {
+            type: 'string',
+            default: '16.3',
+          },
+        },
       },
     },
     jobs: {

--- a/tests/Config.test.ts
+++ b/tests/Config.test.ts
@@ -88,11 +88,15 @@ describe('Parse a fully complete config', () => {
 
   myConfig.addCustomCommand(customCommand);
 
-  const jobA = new CircleCI.Job('my-job-A', reusableDocker.reuse(), [
-    new CircleCI.reusable.ReusableCommand(customCommand, {
-      greeting: '<< pipeline.parameters.greeting >>',
-    }),
-  ]);
+  const jobA = new CircleCI.Job(
+    'my-job-A',
+    reusableDocker.reuse({ version: '17.2' }),
+    [
+      new CircleCI.reusable.ReusableCommand(customCommand, {
+        greeting: '<< pipeline.parameters.greeting >>',
+      }),
+    ],
+  );
   const jobB = new CircleCI.Job('my-job-B', reusableDocker.reuse(), [
     new CircleCI.reusable.ReusableCommand(customCommand, {
       greeting: 'sup world!',
@@ -147,7 +151,7 @@ describe('Parse a fully complete config', () => {
     },
     jobs: {
       'my-job-A': {
-        executor: 'docker',
+        executor: { name: 'docker', version: '17.2' },
         steps: [
           {
             say_hello: {

--- a/tests/Executor.test.ts
+++ b/tests/Executor.test.ts
@@ -397,7 +397,7 @@ describe('Generate a config with a Reusable Executor with parameters', () => {
 
     expect(
       CircleCI.Validator.validateGenerable(
-        CircleCI.mapping.GenerableType.REUSABLE_EXECUTOR_USAGE,
+        CircleCI.mapping.GenerableType.REUSED_EXECUTOR,
         expectedShapeless,
       ),
     ).toEqual(true);
@@ -465,7 +465,7 @@ describe('Generate a config with a Reusable Executor', () => {
   it('Should validate reusable machine image', () => {
     expect(
       CircleCI.Validator.validateGenerable(
-        CircleCI.mapping.GenerableType.REUSABLE_EXECUTOR_USAGE,
+        CircleCI.mapping.GenerableType.REUSED_EXECUTOR,
         {
           executor: {
             name: 'default',
@@ -489,7 +489,7 @@ describe('Generate a config with a Reusable Executor', () => {
   it('Should validate reusable base image shapeless', () => {
     expect(
       CircleCI.Validator.validateGenerable(
-        CircleCI.mapping.GenerableType.REUSABLE_EXECUTOR_USAGE,
+        CircleCI.mapping.GenerableType.REUSED_EXECUTOR,
         {
           executor: 'base',
         },
@@ -500,7 +500,7 @@ describe('Generate a config with a Reusable Executor', () => {
   it('Should validate reusable base image', () => {
     expect(
       CircleCI.Validator.validateGenerable(
-        CircleCI.mapping.GenerableType.REUSABLE_EXECUTOR_USAGE,
+        CircleCI.mapping.GenerableType.REUSED_EXECUTOR,
         {
           executor: {
             name: 'base',

--- a/tests/Job.test.ts
+++ b/tests/Job.test.ts
@@ -1,5 +1,6 @@
 import * as YAML from 'yaml';
 import * as CircleCI from '../src/index';
+import { GenerableType } from '../src/lib/Config/exports/Mapping';
 
 describe('Instantiate Docker Job', () => {
   const docker = new CircleCI.executors.DockerExecutor('cimg/node:lts');
@@ -246,6 +247,10 @@ describe('Parse Docker Job With A Parameterized Custom Command', () => {
     );
 
     expect(result).toEqual(job);
+  });
+
+  it('Should have correct static properties', () => {
+    expect(job.generableType).toEqual(GenerableType.JOB);
   });
 
   // TODO: Make these tests pass. Something weird with having multiple config validators


### PR DESCRIPTION
Previously, we had reusable executors which were serving as usage and definition. This was incorrect and this PR implements ReusedExecutor to solve that, along with helper functions to make using executors easier.