### PR TITLE
feat: add addEnvVar to components

### DIFF
--- a/src/lib/Components/Commands/exports/Native/Run.ts
+++ b/src/lib/Components/Commands/exports/Native/Run.ts
@@ -38,6 +38,27 @@ export class Run implements Command {
     return 'run';
   }
 
+  /**
+   * Add an environment variable to the command.
+   * This will be set in plain-text via the exported config file.
+   * Consider using project-level environment variables or a context for sensitive information.
+   * @see {@link https://circleci.com/docs/env-vars}
+   * @example
+   * ```
+   * myCommand.addEnvVar('MY_VAR', 'my value');
+   * ```
+   */
+  addEnvVar(name: string, value: string): this {
+    if (!this.parameters.environment) {
+      this.parameters.environment = {
+        [name]: value,
+      };
+    } else {
+      this.parameters.environment[name] = value;
+    }
+    return this;
+  }
+
   get generableType(): GenerableType {
     return GenerableType.RUN;
   }

--- a/src/lib/Components/Executors/exports/Executor.ts
+++ b/src/lib/Components/Executors/exports/Executor.ts
@@ -18,7 +18,7 @@ export abstract class Executor<
 > implements Generable
 {
   resource_class: ResourceClass;
-  parameters?: ExecutableParameters;
+  parameters: ExecutableParameters;
 
   /**
    * @param resource_class - The resource class of the environment
@@ -29,7 +29,7 @@ export abstract class Executor<
     parameters?: Exclude<ExecutableParameters, 'resource_class'>,
   ) {
     this.resource_class = resource_class;
-    this.parameters = parameters;
+    this.parameters = parameters || {};
   }
   abstract get generableType(): GenerableType;
   abstract get executorLiteral(): ExecutorLiteral;
@@ -51,5 +51,26 @@ export abstract class Executor<
     parameters?: CustomParametersList<ExecutorParameterLiteral>,
   ): ReusableExecutor {
     return new ReusableExecutor(name, this, parameters);
+  }
+
+  /**
+   * Add an environment variable to the Executor.
+   * This will be set in plain-text via the exported config file.
+   * Consider using project-level environment variables or a context for sensitive information.
+   * @see {@link https://circleci.com/docs/env-vars}
+   * @example
+   * ```
+   * myExecutor.addEnvVar('MY_VAR', 'my value');
+   * ```
+   */
+  addEnvVar(name: string, value: string): this {
+    if (!this.parameters.environment) {
+      this.parameters.environment = {
+        [name]: value,
+      };
+    } else {
+      this.parameters.environment[name] = value;
+    }
+    return this;
   }
 }

--- a/src/lib/Components/Job/types/Job.types.ts
+++ b/src/lib/Components/Job/types/Job.types.ts
@@ -3,17 +3,26 @@ import { Executor } from '../../Executors';
 import { ReusedExecutor } from '../../Executors/exports/ReusedExecutor';
 import { AnyExecutorShape } from '../../Executors/types/Executor.types';
 import { CustomParametersList } from '../../Parameters';
-import { CustomParametersListShape } from '../../Parameters/types';
+import {
+  CustomParametersListShape,
+  EnvironmentParameter,
+} from '../../Parameters/types';
 import { JobParameterLiteral } from '../../Parameters/types/CustomParameterLiterals.types';
 
 export type JobStepsShape = {
   steps: unknown[]; // CommandSchemas for any command.
 };
 
-export type JobContentsShape = JobStepsShape & AnyExecutorShape;
+export type JobContentsShape = JobStepsShape &
+  AnyExecutorShape &
+  JobEnvironmentShape;
 
 export type JobsShape = {
   [key: string]: JobContentsShape;
+};
+
+export type JobEnvironmentShape = {
+  environment?: EnvironmentParameter;
 };
 
 export type AnyExecutor = ReusedExecutor | Executor;
@@ -33,4 +42,5 @@ export type UnknownJobShape = {
   steps: { [key: string]: unknown }[];
   resource_class: string;
   parameters?: { [key: string]: unknown };
+  environment?: { [key: string]: string };
 };

--- a/src/lib/Components/Parameters/types/index.ts
+++ b/src/lib/Components/Parameters/types/index.ts
@@ -66,7 +66,7 @@ export type ExecutorParameter = Executor;
 /**
  * Parameter type for a map of environment variables. Can only be set on non-parameterizable jobs.
  */
-export type EnvironmentParameter = Map<string, string>;
+export type EnvironmentParameter = Record<string, string>;
 
 export type FilterParameter = {
   /**

--- a/tests/Commands.test.ts
+++ b/tests/Commands.test.ts
@@ -6,6 +6,29 @@ describe('Instantiate a Run step', () => {
   const run = new CircleCI.commands.Run({
     command: 'echo hello world',
   });
+  const runWithEnv = new CircleCI.commands.Run({
+    command: 'echo hello world',
+    environment: {
+      MY_VAR: 'my value',
+    },
+  });
+  const runWithAddedEnv = new CircleCI.commands.Run({
+    command: 'echo hello world',
+  });
+  runWithAddedEnv.addEnvVar('MY_VAR', 'my value');
+
+  const expectedEnvResult = {
+    run: { command: 'echo hello world', environment: { MY_VAR: 'my value' } },
+  };
+
+  it('Should generate a run step with environment variable', () => {
+    expect(runWithEnv.generate()).toEqual(expectedEnvResult);
+  });
+
+  it('Should generate a run step with an added environment variable', () => {
+    expect(runWithAddedEnv.generate()).toEqual(expectedEnvResult);
+  });
+
   const runStep = run.generate(true);
   const expectedResult = { run: 'echo hello world' };
   it('Should generate checkout yaml', () => {

--- a/tests/Executor.test.ts
+++ b/tests/Executor.test.ts
@@ -8,8 +8,22 @@ describe('Instantiate Docker Executor', () => {
     resource_class: 'medium',
   };
 
+  const dockerWithEnv = new CircleCI.executors.DockerExecutor('cimg/node:lts');
+  dockerWithEnv.addEnvVar('MY_VAR', 'my value');
+  const expectedShapeWithEnv = {
+    docker: [{ image: 'cimg/node:lts' }],
+    resource_class: 'medium',
+    environment: {
+      MY_VAR: 'my value',
+    },
+  };
+
   it('Should match the expected output', () => {
     expect(docker.generate()).toEqual(expectedShape);
+  });
+
+  it('Should match the expected output with env var', () => {
+    expect(dockerWithEnv.generate()).toEqual(expectedShapeWithEnv);
   });
 
   it('Docker executor should be instance of an Executor', () => {

--- a/tests/Job.test.ts
+++ b/tests/Job.test.ts
@@ -1,5 +1,5 @@
 import * as YAML from 'yaml';
-import * as CircleCI from '../src//index';
+import * as CircleCI from '../src/index';
 import { GenerableType } from '../src/lib/Config/exports/Mapping';
 
 describe('Instantiate Docker Job', () => {
@@ -171,4 +171,31 @@ describe('Parse Docker Job With A Parameterized Custom Command', () => {
 
   //   expect(resultCommand).not.toEqual(true);
   // });
+});
+
+describe('Instantiate a Job with two environment variables', () => {
+  const docker = new CircleCI.executors.DockerExecutor('cimg/node:lts');
+  const helloWorld = new CircleCI.commands.Run({
+    command: 'echo hello',
+  });
+
+  const job = new CircleCI.Job('my-job', docker);
+  job.addStep(helloWorld);
+  job.addEnvVar('MY_VAR_1', 'value1');
+  job.addEnvVar('MY_VAR_2', 'value2');
+
+  const expectedOutput = `my-job:
+  docker:
+    - image: cimg/node:lts
+  environment:
+    MY_VAR_1: value1
+    MY_VAR_2: value2
+  resource_class: medium
+  steps:
+    - run: echo hello
+`;
+
+  it('Should match the expected output', () => {
+    expect(job.generate(true)).toEqual(YAML.parse(expectedOutput));
+  });
 });


### PR DESCRIPTION
Added the ability to add environment variables to the Job, Run Command, and Executor components.
Implements a method called `addEnvVar()` for the three components.

Example
```ts
myJob.addEnvVar('MY_VAR', 'my value');
```

Closes:
- #130 
