### PR TITLE
fix(executor): fix generateContents method

### DIFF
--- a/src/lib/Components/Executors/exports/DockerExecutor.ts
+++ b/src/lib/Components/Executors/exports/DockerExecutor.ts
@@ -49,9 +49,7 @@ export class DockerExecutor extends Executor {
    */
   generateContents(): DockerExecutorContentsShape {
     const imagesArray: DockerImage[] = [this.image];
-    imagesArray.concat(this.serviceImages);
-
-    return imagesArray;
+    return imagesArray.concat(this.serviceImages);
   }
 
   get generableType(): GenerableType {

--- a/tests/Executor.test.ts
+++ b/tests/Executor.test.ts
@@ -34,6 +34,30 @@ describe('Instantiate Docker Executor', () => {
     expect(docker instanceof CircleCI.executors.Executor).toBeTruthy();
   });
 
+  const dockerWithMultipleImage = new CircleCI.executors.DockerExecutor(
+    'cimg/node:lts',
+  );
+  dockerWithMultipleImage.addServiceImage({
+    image: 'cimg/mysql:5.7',
+  });
+  const expectedShapeWithMultipleImage = {
+    docker: [
+      {
+        image: 'cimg/node:lts',
+      },
+      {
+        image: 'cimg/mysql:5.7',
+      },
+    ],
+    resource_class: 'medium',
+  };
+
+  it('Should match the expected outputh with two images', () => {
+    expect(dockerWithMultipleImage.generate()).toEqual(
+      expectedShapeWithMultipleImage,
+    );
+  });
+
   const reusableExecutor = new CircleCI.reusable.ReusableExecutor(
     'default',
     docker,


### PR DESCRIPTION
This commit fixes an issue that prevents the configuration from being generated for multiple images.