### PR TITLE
feat(#154): Disable aliasDuplicateObjects by default

### DIFF
--- a/src/lib/Config/index.ts
+++ b/src/lib/Config/index.ts
@@ -224,7 +224,7 @@ export class Config
    */
   stringify(flatten?: boolean, options?: YAML.ToStringOptions): string {
     const generatedConfig = this.generate(flatten);
-    const defaultOptions: YAML.ToStringOptions = {
+    const defaultOptions: YAML.ToStringOptions & YAML.CreateNodeOptions = {
       aliasDuplicateObjects: false,
       defaultStringType: YAML.Scalar.PLAIN,
       doubleQuotedMinMultiLineLength: 999,

--- a/src/lib/Config/index.ts
+++ b/src/lib/Config/index.ts
@@ -225,11 +225,11 @@ export class Config
   stringify(flatten?: boolean, options?: YAML.ToStringOptions): string {
     const generatedConfig = this.generate(flatten);
     const defaultOptions: YAML.ToStringOptions = {
+      aliasDuplicateObjects: false,
       defaultStringType: YAML.Scalar.PLAIN,
+      doubleQuotedMinMultiLineLength: 999,
       lineWidth: 0,
       minContentWidth: 0,
-      doubleQuotedMinMultiLineLength: 999,
-      aliasDuplicateObjects: false,
     };
     return this._prependVersionComment(
       YAML.stringify(generatedConfig, options ?? defaultOptions),

--- a/src/lib/Config/index.ts
+++ b/src/lib/Config/index.ts
@@ -229,6 +229,7 @@ export class Config
       lineWidth: 0,
       minContentWidth: 0,
       doubleQuotedMinMultiLineLength: 999,
+      aliasDuplicateObjects: false,
     };
     return this._prependVersionComment(
       YAML.stringify(generatedConfig, options ?? defaultOptions),


### PR DESCRIPTION
Anchors are created by default to deduplicate parts of the generated YAML, which makes it harder to read.

Removing them makes pipelines more "human readable".

This closes #154.