### PR TITLE
feat: add Browser-or-Node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
+        "browser-or-node": "^2.0.0",
         "yaml": "2.1.1"
       },
       "devDependencies": {
@@ -2461,6 +2462,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/browser-or-node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-2.0.0.tgz",
+      "integrity": "sha512-3Lrks/Okgof+/cRguUNG+qRXSeq79SO3hY4QrXJayJofwJwHiGC0qi99uDjsfTwULUFSr1OGVsBkdIkygKjTUA=="
     },
     "node_modules/browserslist": {
       "version": "4.21.3",
@@ -9370,6 +9376,11 @@
       "requires": {
         "fill-range": "^7.0.1"
       }
+    },
+    "browser-or-node": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/browser-or-node/-/browser-or-node-2.0.0.tgz",
+      "integrity": "sha512-3Lrks/Okgof+/cRguUNG+qRXSeq79SO3hY4QrXJayJofwJwHiGC0qi99uDjsfTwULUFSr1OGVsBkdIkygKjTUA=="
     },
     "browserslist": {
       "version": "4.21.3",

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "webpack-node-externals": "^2.5.2"
   },
   "dependencies": {
+    "browser-or-node": "^2.0.0",
     "yaml": "2.1.1"
   },
   "directories": {

--- a/src/lib/Config/Pipeline/index.ts
+++ b/src/lib/Config/Pipeline/index.ts
@@ -1,12 +1,6 @@
 import { Project } from './Project';
 import { Git } from './Git';
-import {
-  isBrowser,
-  isNode,
-  isWebWorker,
-  isJsDom,
-  isDeno,
-} from 'browser-or-node';
+import { isNode } from 'browser-or-node';
 /**
  * Not fully implemented yet. Fetch pipeline parameters from inside a CircleCI job.
  * @alpha

--- a/src/lib/Config/Pipeline/index.ts
+++ b/src/lib/Config/Pipeline/index.ts
@@ -1,5 +1,12 @@
 import { Project } from './Project';
 import { Git } from './Git';
+import {
+  isBrowser,
+  isNode,
+  isWebWorker,
+  isJsDom,
+  isDeno,
+} from 'browser-or-node';
 /**
  * Not fully implemented yet. Fetch pipeline parameters from inside a CircleCI job.
  * @alpha
@@ -13,8 +20,12 @@ export class Pipeline {
    * Array of user defined parameters
    */
   constructor() {
-    if (process.env.CIRCLECI == 'true') {
-      this._isLocal = false;
+    if (isNode) {
+      if (process.env.CIRCLECI == 'true') {
+        this._isLocal = false;
+      } else {
+        this._isLocal = true;
+      }
     } else {
       this._isLocal = true;
     }


### PR DESCRIPTION
Resolved issues when loading the SDK in the browser due to usage of the `process` API which is node only.
Added a new zero-dependency package for easily determining the current environment for creating decision trees based on node vs browser.