### PR TITLE
build: use `stripInternal` for tsc build

### DIFF
--- a/tsconfig.json
+++ b/tsconfig.json
@@ -6,6 +6,7 @@
     "declaration": true,
     "declarationMap": true,
     "sourceMap": true,
+    "stripInternal": true,
     "strict": true,
     "noImplicitAny": true,
     "strictNullChecks": true,


### PR DESCRIPTION
Prevents `@internal` types from being included in final artifacts.

### Problem
Currently, the [`@internal Generable` type](https://github.com/CircleCI-Public/circleci-config-sdk-ts/blob/79e0b77c03487baac74899d0cfd75f710954766d/src/lib/Components/index.ts#L6) is being included in the published package. When building against it with `tsc`, we are getting errors such as:
```
node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts:18:5 - error TS1131: Property or signature expected.

18     get generableType(): GenerableType;
       ~~~

node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts:18:9 - error TS1005: ';' expected.

18     get generableType(): GenerableType;
           ~~~~~~~~~~~~~

node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts:18:24 - error TS1005: ';' expected.

18     get generableType(): GenerableType;
                          ~

node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts:19:1 - error TS1128: Declaration or statement expected.

19 }
   ~
```

### Solution
Use `stripInternal` in the `tsconfig`'s `compilerOptions`, which ensures this gets removed. Without this type in the final product, our `tsc` builds succeed.

### Diff in artifacts
Using `npm run build`, the diff in the generated package is the following:
```diff
diff --git a/node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts b/node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts
index 35b443e..e26a57a 100644
--- a/node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts
+++ b/node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts
@@ -1,20 +1,2 @@
-import { GenerableType } from '../Config/exports/Mapping';
-/**
- * @internal
- */
-export interface Generable {
-    /**
-     * Generate the CircleCI YAML equivalent JSON for config compilation
-     * Generable's name is the key in the output.
-     */
-    generate(flatten?: boolean): unknown;
-    /**
-     * Generate the CircleCI YAML equivalent JSON contents for config compilation
-     */
-    generateContents?(flatten?: boolean): unknown;
-    /**
-     * Type of generable object
-     */
-    get generableType(): GenerableType;
-}
+export {};
 //# sourceMappingURL=index.d.ts.map
\ No newline at end of file
diff --git a/node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts.map b/node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts.map
index 7f6c01d..e4534a1 100644
--- a/node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts.map
+++ b/node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts.map
@@ -1 +1 @@
-{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../../../../src/lib/Components/index.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,aAAa,EAAE,MAAM,2BAA2B,CAAC;AAE1D;;GAEG;AACH,MAAM,WAAW,SAAS;IACxB;;;OAGG;IACH,QAAQ,CAAC,OAAO,CAAC,EAAE,OAAO,GAAG,OAAO,CAAC;IAErC;;OAEG;IACH,gBAAgB,CAAC,CAAC,OAAO,CAAC,EAAE,OAAO,GAAG,OAAO,CAAC;IAE9C;;OAEG;IACH,IAAI,aAAa,IAAI,aAAa,CAAC;CACpC"}
\ No newline at end of file
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../../../../src/lib/Components/index.ts"],"names":[],"mappings":""}
\ No newline at end of file
```