### PR TITLE
fix: use appropriate `readonly` for `Generable` interface

### DIFF
--- a/src/lib/Components/index.ts
+++ b/src/lib/Components/index.ts
@@ -18,5 +18,5 @@ export interface Generable {
   /**
    * Type of generable object
    */
-  get generableType(): GenerableType;
+  readonly generableType: GenerableType;
 }


### PR DESCRIPTION
TS interfaces do not actually support the `get`-syntax, and instead should define the property as `readonly` if there is only a getter expected. The usage of `get`/`set` is otherwise left as an implementation detail, not an type definition.

An alternative/additional change to #166 

### Problem
Currently, the [`@internal Generable` type](https://github.com/CircleCI-Public/circleci-config-sdk-ts/blob/79e0b77c03487baac74899d0cfd75f710954766d/src/lib/Components/index.ts#L6) is being included in the published package. When building against it with `tsc`, we are getting errors such as:
```
node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts:18:5 - error TS1131: Property or signature expected.

18     get generableType(): GenerableType;
       ~~~

node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts:18:9 - error TS1005: ';' expected.

18     get generableType(): GenerableType;
           ~~~~~~~~~~~~~

node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts:18:24 - error TS1005: ';' expected.

18     get generableType(): GenerableType;
                          ~

node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts:19:1 - error TS1128: Declaration or statement expected.

19 }
   ~
```

### Solution
Use the appropriate `readonly` property instead of the unexpected getter definition, which is not appropriate in an `interface` in TypeScript.

### Diff in artifacts
Using `npm run build`, the diff in the generated package is the following:
```diff
diff --git a/node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts b/node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts
index 35b443e..1da2696 100644
--- a/node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts
+++ b/node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts
@@ -15,6 +15,6 @@ export interface Generable {
     /**
      * Type of generable object
      */
-    get generableType(): GenerableType;
+    readonly generableType: GenerableType;
 }
 //# sourceMappingURL=index.d.ts.map
\ No newline at end of file
diff --git a/node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts.map b/node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts.map
index 7f6c01d..bfa662c 100644
--- a/node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts.map
+++ b/node_modules/@circleci/circleci-config-sdk/dist/src/lib/Components/index.d.ts.map
@@ -1 +1 @@
-{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../../../../src/lib/Components/index.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,aAAa,EAAE,MAAM,2BAA2B,CAAC;AAE1D;;GAEG;AACH,MAAM,WAAW,SAAS;IACxB;;;OAGG;IACH,QAAQ,CAAC,OAAO,CAAC,EAAE,OAAO,GAAG,OAAO,CAAC;IAErC;;OAEG;IACH,gBAAgB,CAAC,CAAC,OAAO,CAAC,EAAE,OAAO,GAAG,OAAO,CAAC;IAE9C;;OAEG;IACH,IAAI,aAAa,IAAI,aAAa,CAAC;CACpC"}
\ No newline at end of file
+{"version":3,"file":"index.d.ts","sourceRoot":"","sources":["../../../../src/lib/Components/index.ts"],"names":[],"mappings":"AAAA,OAAO,EAAE,aAAa,EAAE,MAAM,2BAA2B,CAAC;AAE1D;;GAEG;AACH,MAAM,WAAW,SAAS;IACxB;;;OAGG;IACH,QAAQ,CAAC,OAAO,CAAC,EAAE,OAAO,GAAG,OAAO,CAAC;IAErC;;OAEG;IACH,gBAAgB,CAAC,CAAC,OAAO,CAAC,EAAE,OAAO,GAAG,OAAO,CAAC;IAE9C;;OAEG;IACH,QAAQ,CAAC,aAAa,EAAE,aAAa,CAAC;CACvC"}
\ No newline at end of file
```