### PR TITLE
feat!: standardize workflow job parameters

### DIFF
--- a/src/lib/Components/Workflow/exports/Workflow.ts
+++ b/src/lib/Components/Workflow/exports/Workflow.ts
@@ -81,13 +81,8 @@ export class Workflow implements Generable, Conditional {
   /**
    * Add a Job to the current Workflow. Chainable
    */
-  addJob(
-    job: Job,
-    parameters?: WorkflowJobParameters,
-    pre_steps?: Command[],
-    post_steps?: Command[],
-  ): this {
-    this.jobs.push(new WorkflowJob(job, parameters, pre_steps, post_steps));
+  addJob(job: Job, parameters?: WorkflowJobParameters): this {
+    this.jobs.push(new WorkflowJob(job, parameters));
     return this;
   }
 

--- a/src/lib/Components/Workflow/exports/Workflow.ts
+++ b/src/lib/Components/Workflow/exports/Workflow.ts
@@ -1,6 +1,5 @@
 import { Generable } from '../..';
 import { GenerableType } from '../../../Config/exports/Mapping';
-import { Command } from '../../Commands/types/Command.types';
 import { Job } from '../../Job';
 import { When } from '../../Logic';
 import { Conditional } from '../../Logic/exports/Conditional';
@@ -72,10 +71,13 @@ export class Workflow implements Generable, Conditional {
 
     const generatedWhen = this.when?.generate();
 
-    return {
-      when: generatedWhen,
+    const workflowContents: WorkflowContentsShape = {
       jobs: generatedWorkflowJobs,
     };
+
+    generatedWhen ? (workflowContents.when = generatedWhen) : null;
+
+    return workflowContents;
   }
 
   /**

--- a/src/lib/Components/Workflow/exports/WorkflowJob.ts
+++ b/src/lib/Components/Workflow/exports/WorkflowJob.ts
@@ -18,26 +18,18 @@ import { WorkflowJobAbstract } from './WorkflowJobAbstract';
  */
 export class WorkflowJob extends WorkflowJobAbstract {
   job: Job | OrbRef<JobParameterLiteral>;
-  pre_steps?: StepsParameter;
-  post_steps?: StepsParameter;
 
   constructor(
     job: Job | OrbRef<JobParameterLiteral>,
     parameters?: Exclude<WorkflowJobParameters, 'type'>,
-    pre_steps?: StepsParameter,
-    post_steps?: StepsParameter,
   ) {
     super(parameters);
     this.job = job;
-    this.pre_steps = pre_steps;
-    this.post_steps = post_steps;
   }
 
   generateContents(flatten?: boolean): WorkflowJobContentsShape {
     return {
       ...super.generateContents(flatten),
-      'pre-steps': this.generateSteps(this.pre_steps, flatten),
-      'post-steps': this.generateSteps(this.post_steps, flatten),
     };
   }
 
@@ -54,7 +46,7 @@ export class WorkflowJob extends WorkflowJobAbstract {
   get name(): string {
     return this.job.name;
   }
-
+  // currently unused
   private generateSteps(
     steps?: StepsParameter,
     flatten?: boolean,

--- a/src/lib/Components/Workflow/exports/WorkflowJob.ts
+++ b/src/lib/Components/Workflow/exports/WorkflowJob.ts
@@ -1,7 +1,5 @@
 import { OrbRef } from '../../../Orb/exports/OrbRef';
-import { AnyCommandShape } from '../../Commands/types/Command.types';
 import { Job } from '../../Job';
-import { StepsParameter } from '../../Parameters/types';
 import { JobParameterLiteral } from '../../Parameters/types/CustomParameterLiterals.types';
 import {
   WorkflowJobContentsShape,
@@ -45,12 +43,5 @@ export class WorkflowJob extends WorkflowJobAbstract {
 
   get name(): string {
     return this.job.name;
-  }
-  // currently unused
-  private generateSteps(
-    steps?: StepsParameter,
-    flatten?: boolean,
-  ): AnyCommandShape[] | undefined {
-    return steps?.map((step) => step.generate(flatten));
   }
 }

--- a/src/lib/Components/Workflow/exports/WorkflowJobAbstract.ts
+++ b/src/lib/Components/Workflow/exports/WorkflowJobAbstract.ts
@@ -25,13 +25,20 @@ export abstract class WorkflowJobAbstract implements Generable {
     let parameters: WorkflowJobParametersShape | undefined;
 
     if (this.parameters) {
-      const { matrix, ...jobParameters } = this.parameters;
+      const { matrix, preSteps, postSteps, ...jobParameters } = this.parameters;
       parameters = jobParameters;
 
       if (matrix) {
         parameters.matrix = {
           parameters: matrix,
         };
+      }
+
+      if (preSteps) {
+        parameters['pre-steps'] = preSteps.map((step) => step.generate());
+      }
+      if (postSteps) {
+        parameters['post-steps'] = postSteps.map((step) => step.generate());
       }
     }
 

--- a/src/lib/Components/Workflow/exports/WorkflowJobAbstract.ts
+++ b/src/lib/Components/Workflow/exports/WorkflowJobAbstract.ts
@@ -1,5 +1,7 @@
 import { GenerableType } from '../../../Config/exports/Mapping';
+import { AnyCommandShape } from '../../Commands/types/Command.types';
 import { Generable } from '../../index';
+import { StepsParameter } from '../../Parameters/types';
 import {
   WorkflowJobContentsShape,
   WorkflowJobParameters,
@@ -35,10 +37,10 @@ export abstract class WorkflowJobAbstract implements Generable {
       }
 
       if (preSteps) {
-        parameters['pre-steps'] = preSteps.map((step) => step.generate());
+        parameters['pre-steps'] = this.generateSteps(preSteps, flatten);
       }
       if (postSteps) {
-        parameters['post-steps'] = postSteps.map((step) => step.generate());
+        parameters['post-steps'] = this.generateSteps(postSteps, flatten);
       }
     }
 
@@ -47,6 +49,13 @@ export abstract class WorkflowJobAbstract implements Generable {
 
   get generableType(): GenerableType {
     return GenerableType.WORKFLOW_JOB;
+  }
+
+  private generateSteps(
+    steps?: StepsParameter,
+    flatten?: boolean,
+  ): AnyCommandShape[] | undefined {
+    return steps?.map((step) => step.generate(flatten));
   }
 
   abstract get name(): string;

--- a/src/lib/Components/Workflow/types/Workflow.types.ts
+++ b/src/lib/Components/Workflow/types/Workflow.types.ts
@@ -4,13 +4,13 @@ import { WorkflowJobShape } from './WorkflowJob.types';
 
 export type WorkflowsShape = {
   [workflowName: string]: {
-    when: AnyConditionShape;
+    when?: AnyConditionShape;
     jobs: WorkflowJobShape[];
   };
 };
 
 export type WorkflowContentsShape = {
-  when: AnyConditionShape;
+  when?: AnyConditionShape;
   jobs: WorkflowJobShape[];
 };
 

--- a/src/lib/Components/Workflow/types/Workflow.types.ts
+++ b/src/lib/Components/Workflow/types/Workflow.types.ts
@@ -23,8 +23,6 @@ export type UnknownWorkflowJobShape = {
   parameters?: { [key: string]: unknown };
   name?: string;
   type?: 'approval';
-  // 'pre-steps'?: { [key: string]: unknown }[];
-  // 'post-steps'?: { [key: string]: unknown }[];
 };
 
 export type WorkflowDependencies = {

--- a/src/lib/Components/Workflow/types/WorkflowJob.types.ts
+++ b/src/lib/Components/Workflow/types/WorkflowJob.types.ts
@@ -23,6 +23,8 @@ export interface WorkflowJobParameters
   requires?: ListParameter;
   name?: StringParameter;
   context?: ListParameter;
+  preSteps?: StepsParameter;
+  postSteps?: StepsParameter;
   /**
    * {@link https://circleci.com/docs/2.0/configuration-reference/#filters} Filter workflow job's execution by branch or git tag.
    */
@@ -35,9 +37,6 @@ export interface WorkflowJobParameters
    * An "approval" type job is a special job which pauses the workflow. This "job" is not defined outside of the workflow, you may enter any potential name for the job name. As long as the parameter of "type" is present and equal to "approval" this job will act as a placeholder that awaits user input to continue.
    */
   type?: approval;
-
-  pre_steps?: StepsParameter;
-  post_steps?: StepsParameter;
 }
 
 export type approval = 'approval';
@@ -62,8 +61,6 @@ export interface WorkflowJobParametersShape {
   type?: approval;
   filters?: FilterParameter;
   matrix?: WorkflowMatrixShape;
-  'pre-steps'?: AnyCommandShape[];
-  'post-steps'?: AnyCommandShape[];
   [key: string]:
     | JobParameterTypes
     | WorkflowMatrixShape

--- a/tests/Workflow.test.ts
+++ b/tests/Workflow.test.ts
@@ -1,4 +1,5 @@
 import * as CircleCI from '../src/index';
+import * as YAML from 'yaml';
 
 describe('Instantiate Workflow', () => {
   const docker = new CircleCI.executors.DockerExecutor('cimg/node:lts');
@@ -289,28 +290,26 @@ describe('Add pre/post steps to workflow', () => {
   });
   const job = new CircleCI.Job('my-job', docker, [helloWorld]);
   const myWorkflow = new CircleCI.Workflow('my-workflow');
-  myWorkflow.addJob(
-    job,
-    {
-      name: 'custom-name',
-    },
-    [helloWorld],
-    [helloWorld],
-  );
+  myWorkflow.addJob(job, {
+    name: 'custom-name',
+    preSteps: [helloWorld],
+    postSteps: [helloWorld],
+  });
   it('Should match the expected output', () => {
-    const expected = {
-      'my-workflow': {
-        jobs: [
-          {
-            'my-job': {
-              name: 'custom-name',
-              'post-steps': [{ run: 'echo hello world' }],
-              'pre-steps': [{ run: 'echo hello world' }],
-            },
-          },
-        ],
-      },
-    };
+    const expectedYaml = `workflows:
+  my-workflow:
+    jobs:
+      - my-job:
+          name: custom-name
+          pre-steps:
+            - run:
+                command: echo hello world
+          post-steps:
+            - run:
+                command: echo hello world
+`;
+    const expected = YAML.parse(expectedYaml);
+
     const generatedWorkflow = myWorkflow.generate(true);
     expect(generatedWorkflow).toEqual(expected);
   });

--- a/tests/Workflow.test.ts
+++ b/tests/Workflow.test.ts
@@ -296,17 +296,16 @@ describe('Add pre/post steps to workflow', () => {
     postSteps: [helloWorld],
   });
   it('Should match the expected output', () => {
-    const expectedYaml = `workflows:
-  my-workflow:
-    jobs:
-      - my-job:
-          name: custom-name
-          pre-steps:
-            - run:
-                command: echo hello world
-          post-steps:
-            - run:
-                command: echo hello world
+    const expectedYaml = `my-workflow:
+  jobs:
+    - my-job:
+        name: custom-name
+        pre-steps:
+          - run:
+              command: echo hello world
+        post-steps:
+          - run:
+              command: echo hello world
 `;
     const expected = YAML.parse(expectedYaml);
 

--- a/tests/Workflow.test.ts
+++ b/tests/Workflow.test.ts
@@ -301,11 +301,9 @@ describe('Add pre/post steps to workflow', () => {
     - my-job:
         name: custom-name
         pre-steps:
-          - run:
-              command: echo hello world
+          - run: echo hello world
         post-steps:
-          - run:
-              command: echo hello world
+          - run: echo hello world
 `;
     const expected = YAML.parse(expectedYaml);
 


### PR DESCRIPTION
WorkflowJobs no longer have specific properties for `preSteps` or `postSteps`, instead these are now expected to be passed as additional parameters within the parameters object.

The new syntax for using pre/postSteps:

```ts
  myWorkflow.addJob(job, {
    name: 'custom-name',
    preSteps: [helloWorld],
    postSteps: [helloWorld],
  });
```

This will produce the following output:

```yaml
my-workflow:
  jobs:
    - my-job:
        name: custom-name
        pre-steps:
          - run: echo hello world
        post-steps:
          - run: echo hello world
````

---

Additionally, this PR resolves an issue I came across in testing that does not appear reported. Previously the `when` key for workflows appeared to be required and would output an undefined value. This key will no longer be added if undefined.