### PR TITLE
fix: Call generate on custom step parameters

### DIFF
--- a/src/lib/Components/Workflow/exports/WorkflowJobAbstract.ts
+++ b/src/lib/Components/Workflow/exports/WorkflowJobAbstract.ts
@@ -28,6 +28,9 @@ export abstract class WorkflowJobAbstract implements Generable {
 
     if (this.parameters) {
       const { matrix, preSteps, postSteps, ...jobParameters } = this.parameters;
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+      const { requires, context, filters, name, type, ...customParameters } =
+        jobParameters;
       parameters = jobParameters;
 
       if (matrix) {
@@ -41,6 +44,18 @@ export abstract class WorkflowJobAbstract implements Generable {
       }
       if (postSteps) {
         parameters['post-steps'] = this.generateSteps(postSteps, flatten);
+      }
+
+      for (const [name, jp] of Object.entries(customParameters)) {
+        if (jp && Array.isArray(jp)) {
+          parameters[name] = jp.map(function (param) {
+            if (typeof param === 'string') {
+              return param;
+            }
+
+            return param.generate(flatten);
+          });
+        }
       }
     }
 


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [X] The commit message follows our contributor [guidelines](https://github.com/CircleCI-Public/circleci-config-sdk-ts/blob/main/CONTRIBUTING.md).
- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Documentation has been added or updated where needed.

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bug fix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Other... Please describe:

> more details

## What issues are resolved by this PR?
<!-- All Pull Requests should be a response to an existing issue. Please ensure you have created an issue before submitting a PR. -->
- #161 

## Describe the new behavior.
<!-- Describe the new behavior introduced by this change. Include an examples or samples needed, such as screenshots or code snippets. -->

> Description
When passing custom step parameters to a job within a workflow the commands get generated incorrectly. For example when trying to pass commands coming from an orb, like so:

`pre_lint: [composer, 'test', typecheck],`

Before the change:
```
- mindful/lint-and-unit-test:
          pre_lint:
            - name: mindful/composer
              parameters:
                environment_id: << pipeline.parameters.deployment_type >>
                instance_id: << pipeline.parameters.instance_type >>
            - test
            - parameters:
                name: Typecheck
                command: yarn run typecheck
```

After the change:
```
- mindful/lint-and-unit-test:
          pre_lint:
            - mindful/composer:
                environment_id: << pipeline.parameters.deployment_type >>
                instance_id: << pipeline.parameters.instance_type >>
            - test
            - run:
                name: Typecheck
                command: yarn run typecheck
```
## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
<!-- Optional. -->

> More information (optional)

The linked issue is more of a general description but I believe it applies here too. If a new issue needs to be opened I can do that as well.
